### PR TITLE
refactor(sdk): move db and sequencer clients to zod schemas and separ…

### DIFF
--- a/sdk/src/client/pouchdb.js
+++ b/sdk/src/client/pouchdb.js
@@ -1,0 +1,64 @@
+import { of, Rejected, Resolved } from "hyper-async";
+import { __, always, applySpec, head, prop } from "ramda";
+import { z } from "zod";
+
+/**
+ * An implementation of the db client using pouchDB
+ */
+
+const cachedInteractionDocSchema = z.object({
+  _id: z.string().min(1),
+  contractId: z.string().min(1),
+  createdAt: z.preprocess(
+    (
+      arg,
+    ) => (typeof arg == "string" || arg instanceof Date ? new Date(arg) : arg),
+    z.date(),
+  ),
+  output: z.object({
+    state: z.record(z.any()).optional(),
+    result: z.record(z.any()).optional(),
+  }),
+  type: z.literal("interaction"),
+});
+
+export function findLatestInteraction({ id, to }) {
+  // TODO: implement to fetch from PouchDB. Mock for now
+  return of([])
+    .map(head)
+    .chain((doc) => doc ? Resolved(doc) : Rejected(doc))
+    /**
+     * Ensure the input matches the expected
+     * shape
+     */
+    .map(cachedInteractionDocSchema.parse)
+    .map(applySpec({
+      id: prop("_id"),
+      contractId: prop("contractId"),
+      output: prop("output"),
+      createdAt: prop("createdAt"),
+    }))
+    .bichain(Resolved, Resolved)
+    .toPromise();
+}
+
+export function saveInteraction(interaction) {
+  return of(interaction)
+    /**
+     * Ensure the output matches the expected
+     * shape
+     */
+    .map(cachedInteractionDocSchema.parse)
+    .map(applySpec({
+      _id: prop("id"),
+      contractId: prop("contractId"),
+      output: prop("output"),
+      createdAt: prop("createdAt"),
+      type: always("interaction"),
+    }))
+    .chain((interactionDocs) => {
+      // TODO: implement bulk save to PouchDB, mock for now
+      return Resolved(interactionDocs);
+    })
+    .toPromise();
+}

--- a/sdk/src/client/pouchdb.test.js
+++ b/sdk/src/client/pouchdb.test.js
@@ -1,0 +1,11 @@
+import { describe, test } from "node:test";
+
+describe("pouchdb", () => {
+  describe("findLatestInteraction", () => {
+    // TODO
+  });
+
+  describe("saveInteraction", () => {
+    // TODO
+  });
+});

--- a/sdk/src/client/warp-sequencer.js
+++ b/sdk/src/client/warp-sequencer.js
@@ -1,0 +1,201 @@
+import { fromPromise, of } from "hyper-async";
+import {
+  __,
+  applySpec,
+  assoc,
+  compose,
+  evolve,
+  map,
+  path,
+  pipe,
+  prop,
+  reduce,
+  transduce,
+} from "ramda";
+import { z } from "zod";
+
+import { interactionSchema } from "../dal.js";
+
+/**
+ * An implementation of the Sequencer client using
+ * the Warp Sequencer
+ */
+
+/**
+ * @typedef Env3
+ * @property {fetch} fetch
+ * @property {string} SEQUENCER_URL
+ *
+ * @typedef LoadInteractionsArgs
+ * @property {string} id - the contract id
+ * @property {string} from - the lower-most block height
+ * @property {string} to - the upper-most block height
+ *
+ * @callback LoadInteractions
+ * @param {LoadInteractionsArgs} args
+ * @returns {Async<Record<string, any>}
+ *
+ * @param {Env3} env
+ * @returns {LoadInteractions}
+ */
+export function loadInteractionsWith({ fetch, SEQUENCER_URL }) {
+  // TODO: create a dataloader and use that to batch load interactions
+
+  const interactionsPageSchema = z.object({
+    paging: z.record(z.any()),
+    interactions: z.array(z.object({
+      interaction: z.object({
+        tags: z.array(z.object({
+          name: z.string(),
+          value: z.string(),
+        })),
+        block: z.object({
+          id: z.string(),
+          /**
+           * These come back as strings from the sequencer
+           * despite the values actually being numbers
+           * on the graph
+           *
+           * So we will coerce them to a number
+           */
+          height: z.coerce.number(),
+          timestamp: z.coerce.number(),
+        }),
+        sortKey: z.string(),
+      }),
+    })),
+  });
+
+  /**
+   * Pad the block height portion of the sortKey to 12 characters
+   *
+   * This should work to increment and properly pad any sort key:
+   * - 000001257294,1694181441598,fb1ebd7d621d1398acc03e108b7a593c6960c6e522772c974cd21c2ba7ac11d5 (full Sequencer sort key)
+   * - 000001257294,fb1ebd7d621d1398acc03e108b7a593c6960c6e522772c974cd21c2ba7ac11d5 (Smartweave protocol sort key)
+   * - 1257294,1694181441598,fb1ebd7d621d1398acc03e108b7a593c6960c6e522772c974cd21c2ba7ac11d5 (missing padding)
+   * - 1257294 (just block height)
+   *
+   * @param {string} sortKey - the sortKey to be padded. If the sortKey is of sufficient length, then no padding
+   * is added.
+   */
+  const padBlockHeight = (sortKey) => {
+    if (!sortKey) return sortKey;
+    const [height, ...rest] = String(sortKey).split(",");
+    return [height.padStart(12, "0"), ...rest].join(",");
+  };
+
+  const mapBounds = evolve({
+    from: padBlockHeight,
+    to: pipe(
+      /**
+       * Potentially increment the block height by 1, so
+       * the sequencer will include any interactions in that block
+       */
+      (sortKey) => {
+        if (!sortKey) return sortKey;
+        const parts = String(sortKey).split(",");
+        /**
+         * Full sort key, so no need to increment
+         */
+        if (parts.length > 1) return parts.join(",");
+
+        /**
+         * only the block height is being used as the sort key
+         */
+        const [height] = parts;
+        if (!height) return height;
+        const num = parseInt(height);
+        return String(num + 1);
+      },
+      /**
+       * Still ensure the proper padding is added
+       */
+      padBlockHeight,
+    ),
+  });
+
+  /**
+   * See https://academy.warp.cc/docs/gateway/http/get/interactions
+   */
+  return (ctx) =>
+    of({ id: ctx.id, from: ctx.from, to: ctx.to })
+      .map(mapBounds)
+      .chain(fromPromise(({ id, from, to }) =>
+        /**
+         * A couple quirks to highlight here:
+         *
+         * - The sequencer returns interactions sorted by block height, DESCENDING order
+         *   so in order to fold interactions, chronologically, we need to reverse the order of interactions
+         *   prior to returning (see unshift instead of push in trasducer below)
+         *
+         * - The block height included in both to and from need to be left padded with 0's to reach 12 characters (See https://academy.warp.cc/docs/sdk/advanced/bundled-interaction#how-it-works)
+         *   (see padBlockHeight above or impl)
+         *
+         * - 'from' is inclusive
+         *
+         * - 'to' is non-inclusive IF only the block height is used at the sort key, so if we want to include interactions in the block at 'to', then we need to increment the block height by 1
+         *    (see mapBounds above where we increment to block height by one)
+         */
+        fetch(
+          // TODO: need to be able to load multiple pages until all interactions are fetched
+          `${SEQUENCER_URL}/gateway/v2/interactions-sort-key?contractId=${id}&from=${from}&to=${to}`,
+        )
+          .then((res) => res.json())
+          .then(interactionsPageSchema.parse)
+          .then(prop("interactions"))
+          .then((interactions) =>
+            transduce(
+              // { interaction: { tags: [ { name, value }] } }
+              compose(
+                // [ { name, value } ]
+                map(path(["interaction"])),
+                map(applySpec({
+                  sortKey: prop("sortKey"),
+                  action: pipe(
+                    path(["tags"]),
+                    // { first: tag, second: tag }
+                    reduce((a, t) => assoc(t.name, t.value, a), {}),
+                    // "{\"function\": \"balance\"}"
+                    prop("Input"),
+                    // { function: "balance" }
+                    (input) => JSON.parse(input),
+                  ),
+                })),
+              ),
+              (acc, input) => {
+                acc.unshift(input);
+                return acc;
+              },
+              [],
+              interactions,
+            )
+          )
+          .then(z.array(interactionSchema).parse)
+      )).toPromise();
+}
+
+/**
+ * @typedef Env3
+ * @property {fetch} fetch
+ * @property {string} SEQUENCER_URL
+ *
+ * @typedef LoadInteractionsArgs
+ * @property {string} id - the contract id
+ * @property {string} from - the lower-most block height
+ * @property {string} to - the upper-most block height
+ *
+ * @callback LoadInteractions
+ * @param {LoadInteractionsArgs} args
+ * @returns {Async<Record<string, any>}
+ *
+ * @param {Env3} env
+ * @returns {LoadInteractions}
+ */
+export function writeInteractionWith({ fetch, SEQUENCER_URL }) {
+  return async (transaction) => {
+    // verify input
+    // construct request to sequencer ie. url, body, headers
+    // make call
+    // return shape that we care about
+  };
+}

--- a/sdk/src/client/warp-sequencer.test.js
+++ b/sdk/src/client/warp-sequencer.test.js
@@ -1,0 +1,33 @@
+import { describe, test } from "node:test";
+import * as assert from "node:assert";
+
+import { loadInteractionsWith } from "./warp-sequencer.js";
+
+const SEQUENCER_URL = "https://gw.warp.cc";
+const CONTRACT = "SFKREVkacx7N64SIfAuNkMOPTocm42qbkKwzRJGfQHY";
+
+describe("warp-sequencer", () => {
+  describe("loadInteractions", () => {
+    test("load the interactions from the sequencer", async () => {
+      const loadInteractions = loadInteractionsWith({
+        fetch,
+        SEQUENCER_URL,
+      });
+
+      const res = await loadInteractions({
+        id: CONTRACT,
+        from: "",
+        to: "",
+      });
+      assert.ok(res.length);
+      const [firstInteraction] = res;
+      assert.ok(firstInteraction.action);
+      assert.ok(firstInteraction.action.function);
+      assert.ok(firstInteraction.sortKey);
+    });
+  });
+
+  describe("writeInteraction", () => {
+    // TODO
+  });
+});

--- a/sdk/src/dal.js
+++ b/sdk/src/dal.js
@@ -1,83 +1,15 @@
-import { fromPromise, of, Rejected, Resolved } from "hyper-async";
-import {
-  __,
-  always,
-  applySpec,
-  assoc,
-  compose,
-  evolve,
-  head,
-  map,
-  path,
-  pipe,
-  prop,
-  reduce,
-  transduce,
-} from "ramda";
+import { fromPromise, of } from "hyper-async";
+import { __, path } from "ramda";
 import { z } from "zod";
 
-const GET_CONTRACTS_QUERY = `
-query GetContracts ($contractIds: [ID!]!) {
-  transactions(ids: $contractIds) {
-    edges {
-      node {
-        tags {
-          name
-          value
-        }
-        block {
-          id
-          height
-          timestamp
-        }
-      }
-    }
-  }
-}`;
-
-const transactionConnectionSchema = z.object({
-  data: z.object({
-    transactions: z.object({
-      edges: z.array(z.object({
-        node: z.record(z.any()),
-      })),
-    }),
-  }),
-});
-
-const interactionsPageSchema = z.object({
-  paging: z.record(z.any()),
-  interactions: z.array(z.object({
-    interaction: z.object({
-      tags: z.array(z.object({
-        name: z.string(),
-        value: z.string(),
-      })),
-      block: z.object({
-        id: z.string(),
-        /**
-         * These come back as strings from the sequencer
-         * despite the values actually being numbers
-         * on the graph
-         *
-         * So we will coerce them to a number
-         */
-        height: z.coerce.number(),
-        timestamp: z.coerce.number(),
-      }),
-      sortKey: z.string(),
-    }),
-  })),
-});
-
-const interactionSchema = z.object({
+export const interactionSchema = z.object({
   action: z.object({
     function: z.string(),
   }).passthrough(),
   sortKey: z.string(),
 });
 
-export const cachedInteractionSchema = z.object({
+const cachedInteractionSchema = z.object({
   /**
    * The sort key of the interaction
    */
@@ -111,11 +43,24 @@ export const cachedInteractionSchema = z.object({
   }),
 });
 
-const cachedInteractionDocSchema = cachedInteractionSchema.omit({ id: true })
-  .extend({
-    _id: z.string().min(1),
-    type: z.literal("interaction"),
-  });
+export const dbClientSchema = z.object({
+  findLatestInteraction: z.function()
+    .args(z.object({ id: z.string(), to: z.string() }))
+    .returns(z.promise(cachedInteractionSchema)),
+  saveInteraction: z.function()
+    .args(cachedInteractionSchema)
+    .returns(z.promise(z.any())),
+});
+
+export const sequencerClientSchema = z.object({
+  loadInteractions: z.function()
+    .args(z.object({ id: z.string(), from: z.string(), to: z.string() }))
+    .returns(z.promise(z.array(interactionSchema))),
+  // TODO: define this shape
+  writeInteraction: z.function()
+    .args(z.record(z.any()))
+    .returns(z.promise(z.any())),
+});
 
 /**
  * @typedef Env1
@@ -131,6 +76,35 @@ const cachedInteractionDocSchema = cachedInteractionSchema.omit({ id: true })
  */
 export function loadTransactionMetaWith({ fetch, GATEWAY_URL }) {
   // TODO: create a dataloader and use that to batch load contracts
+
+  const GET_CONTRACTS_QUERY = `
+  query GetContracts ($contractIds: [ID!]!) {
+    transactions(ids: $contractIds) {
+      edges {
+        node {
+          tags {
+            name
+            value
+          }
+          block {
+            id
+            height
+            timestamp
+          }
+        }
+      }
+    }
+  }`;
+
+  const transactionConnectionSchema = z.object({
+    data: z.object({
+      transactions: z.object({
+        edges: z.array(z.object({
+          node: z.record(z.any()),
+        })),
+      }),
+    }),
+  });
 
   return (id) =>
     of(id)
@@ -168,249 +142,3 @@ export function loadTransactionDataWith({ fetch, GATEWAY_URL }) {
     of(id)
       .chain(fromPromise((id) => fetch(`${GATEWAY_URL}/${id}`)));
 }
-
-/**
- * @typedef Env3
- * @property {fetch} fetch
- * @property {string} SEQUENCER_URL
- *
- * @typedef LoadInteractionsArgs
- * @property {string} id - the contract id
- * @property {string} from - the lower-most block height
- * @property {string} to - the upper-most block height
- *
- * @callback LoadInteractions
- * @param {LoadInteractionsArgs} args
- * @returns {Async<Record<string, any>}
- *
- * @param {Env3} env
- * @returns {LoadInteractions}
- */
-export function loadInteractionsWith({ fetch, SEQUENCER_URL }) {
-  // TODO: create a dataloader and use that to batch load interactions
-
-  /**
-   * Pad the block height portion of the sortKey to 12 characters
-   *
-   * This should work to increment and properly pad any sort key:
-   * - 000001257294,1694181441598,fb1ebd7d621d1398acc03e108b7a593c6960c6e522772c974cd21c2ba7ac11d5 (full Sequencer sort key)
-   * - 000001257294,fb1ebd7d621d1398acc03e108b7a593c6960c6e522772c974cd21c2ba7ac11d5 (Smartweave protocol sort key)
-   * - 1257294,1694181441598,fb1ebd7d621d1398acc03e108b7a593c6960c6e522772c974cd21c2ba7ac11d5 (missing padding)
-   * - 1257294 (just block height)
-   *
-   * @param {string} sortKey - the sortKey to be padded. If the sortKey is of sufficient length, then no padding
-   * is added.
-   */
-  const padBlockHeight = (sortKey) => {
-    if (!sortKey) return sortKey;
-    const [height, ...rest] = String(sortKey).split(",");
-    return [height.padStart(12, "0"), ...rest].join(",");
-  };
-
-  const mapBounds = evolve({
-    from: padBlockHeight,
-    to: pipe(
-      /**
-       * Potentially increment the block height by 1, so
-       * the sequencer will include any interactions in that block
-       */
-      (sortKey) => {
-        if (!sortKey) return sortKey;
-        const parts = String(sortKey).split(",");
-        /**
-         * Full sort key, so no need to increment
-         */
-        if (parts.length > 1) return parts.join(",");
-
-        /**
-         * only the block height is being used as the sort key
-         */
-        const [height] = parts;
-        if (!height) return height;
-        const num = parseInt(height);
-        return String(num + 1);
-      },
-      /**
-       * Still ensure the proper padding is added
-       */
-      padBlockHeight,
-    ),
-  });
-
-  /**
-   * See https://academy.warp.cc/docs/gateway/http/get/interactions
-   */
-  return (ctx) =>
-    of({ id: ctx.id, from: ctx.from, to: ctx.to })
-      .map(mapBounds)
-      .chain(fromPromise(({ id, from, to }) =>
-        /**
-         * A couple quirks to highlight here:
-         *
-         * - The sequencer returns interactions sorted by block height, DESCENDING order
-         *   so in order to fold interactions, chronologically, we need to reverse the order of interactions
-         *   prior to returning (see unshift instead of push in trasducer below)
-         *
-         * - The block height included in both to and from need to be left padded with 0's to reach 12 characters (See https://academy.warp.cc/docs/sdk/advanced/bundled-interaction#how-it-works)
-         *   (see padBlockHeight above or impl)
-         *
-         * - 'from' is inclusive
-         *
-         * - 'to' is non-inclusive IF only the block height is used at the sort key, so if we want to include interactions in the block at 'to', then we need to increment the block height by 1
-         *    (see mapBounds above where we increment to block height by one)
-         */
-        fetch(
-          // TODO: need to be able to load multiple pages until all interactions are fetched
-          `${SEQUENCER_URL}/gateway/v2/interactions-sort-key?contractId=${id}&from=${from}&to=${to}`,
-        )
-          .then((res) => res.json())
-          .then(interactionsPageSchema.parse)
-          .then(prop("interactions"))
-          .then((interactions) =>
-            transduce(
-              // { interaction: { tags: [ { name, value }] } }
-              compose(
-                // [ { name, value } ]
-                map(path(["interaction"])),
-                map(applySpec({
-                  sortKey: prop("sortKey"),
-                  action: pipe(
-                    path(["tags"]),
-                    // { first: tag, second: tag }
-                    reduce((a, t) => assoc(t.name, t.value, a), {}),
-                    // "{\"function\": \"balance\"}"
-                    prop("Input"),
-                    // { function: "balance" }
-                    (input) => JSON.parse(input),
-                  ),
-                })),
-              ),
-              (acc, input) => {
-                acc.unshift(input);
-                return acc;
-              },
-              [],
-              interactions,
-            )
-          )
-          .then(z.array(interactionSchema).parse)
-      ));
-}
-
-/**
- * @typedef Env3
- * @property {fetch} fetch
- * @property {string} SEQUENCER_URL
- *
- * @typedef LoadInteractionsArgs
- * @property {string} id - the contract id
- * @property {string} from - the lower-most block height
- * @property {string} to - the upper-most block height
- *
- * @callback LoadInteractions
- * @param {LoadInteractionsArgs} args
- * @returns {Async<Record<string, any>}
- *
- * @param {Env3} env
- * @returns {LoadInteractions}
- */
-export function writeInteractionWith({ fetch, SEQUENCER_URL }) {
-  return (transaction) => {
-    // verify input
-    // construct request to sequencer ie. url, body, headers
-    // make call
-    // return shape that we care about
-  };
-}
-
-export const dbWith = ({ dbClient }) => {
-  function findLatestInteraction({ id, to }) {
-    // TODO: implement to fetch from PouchDB. Mock for now
-    return of([])
-      .map(head)
-      .chain((doc) => doc ? Resolved(doc) : Rejected(doc))
-      /**
-       * Ensure the input matches the expected
-       * shape
-       */
-      .map(cachedInteractionDocSchema.parse)
-      .map(applySpec({
-        id: prop("_id"),
-        contractId: prop("contractId"),
-        output: prop("output"),
-        createdAt: prop("createdAt"),
-      }))
-      /**
-       * Ensure the output matches the expected
-       * shape
-       */
-      .map(cachedInteractionSchema.parse)
-      .bichain(Resolved, Resolved);
-  }
-
-  function saveInteraction(interaction) {
-    return saveInteractions([interaction]);
-  }
-
-  /**
-   * TODO: expose publicly? For now, keep internal
-   */
-  function saveInteractions(interactions) {
-    return of(interactions)
-      .map(
-        (interactions) =>
-          /**
-           * Because we could potentially be transforming many interactions,
-           * iterating the array multiple times could have a non-trivial
-           * performance impact
-           *
-           * So we use a transducer which allows us to iterate the array
-           * only once, performing all the transformations, per element, sequentially.
-           *
-           * Reduce + Transform => Transduce
-           */
-          transduce(
-            compose(
-              /**
-               * Ensure the input matches the expected
-               * shape
-               */
-              map(cachedInteractionSchema.parse),
-              map(applySpec({
-                _id: prop("id"),
-                contractId: prop("contractId"),
-                output: prop("output"),
-                createdAt: prop("createdAt"),
-                type: always("interaction"),
-              })),
-              /**
-               * Ensure the output matches the expected
-               * shape
-               */
-              map(cachedInteractionDocSchema.parse),
-            ),
-            /**
-             * We purposefully do not create a new array every time here,
-             * and instead mutate a single array.
-             *
-             * Because we could potentially be saving lots of interactions, so
-             * additional GC churn could slow down this process, non-trivially.
-             */
-            (acc, input) => {
-              acc.unshift(input);
-              return acc;
-            },
-            [],
-            interactions,
-          ),
-      ).chain((interactionDocs) => {
-        // TODO: implement bulk save to PouchDB, mock for now
-        return Resolved(interactionDocs);
-      });
-  }
-
-  return {
-    findLatestInteraction,
-    saveInteraction,
-  };
-};

--- a/sdk/src/dal.test.js
+++ b/sdk/src/dal.test.js
@@ -1,14 +1,9 @@
 import { describe, test } from "node:test";
 import * as assert from "node:assert";
 
-import {
-  loadInteractionsWith,
-  loadTransactionDataWith,
-  loadTransactionMetaWith,
-} from "./dal.js";
+import { loadTransactionDataWith, loadTransactionMetaWith } from "./dal.js";
 
 const GATEWAY_URL = globalThis.GATEWAY || "https://arweave.net";
-const SEQUENCER_URL = globalThis.SEQUENCER_URL || "https://gw.warp.cc";
 const CONTRACT = "zc24Wpv_i6NNCEdxeKt7dcNrqL5w0hrShtSCcFGGL24";
 
 describe("dal", () => {
@@ -90,28 +85,6 @@ describe("dal", () => {
       assert.ok(result.json);
       assert.ok(result.text);
       assert.ok(result.ok);
-    });
-  });
-
-  describe("loadInteractions", () => {
-    test("load the interactions from the sequencer", async () => {
-      const CONTRACT = "SFKREVkacx7N64SIfAuNkMOPTocm42qbkKwzRJGfQHY";
-
-      const loadInteractions = loadInteractionsWith({
-        fetch,
-        SEQUENCER_URL,
-      });
-
-      const res = await loadInteractions({
-        id: CONTRACT,
-        from: "",
-        to: "",
-      }).toPromise();
-      assert.ok(res.length);
-      const [firstInteraction] = res;
-      assert.ok(firstInteraction.action);
-      assert.ok(firstInteraction.action.function);
-      assert.ok(firstInteraction.sortKey);
     });
   });
 });

--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -1,18 +1,49 @@
+import { dbClientSchema, sequencerClientSchema } from "./dal.js";
 import { readStateWith, writeInteractionWith } from "./main.js";
+
+// Precanned clients to use for OOTB apis
+import { findLatestInteraction, saveInteraction } from "./client/pouchdb.js";
+import {
+  loadInteractionsWith,
+  writeInteractionWith,
+} from "./client/warp-sequencer.js";
 
 const GATEWAY_URL = globalThis.GATEWAY || "https://arweave.net";
 const SEQUENCER_URL = globalThis.SEQUENCER_URL || "https://gw.warp.cc";
 
-const dbClient = {};
+/**
+ * TODO: export a 'connect' that allows providing
+ * - own db client impl,
+ * - own sequencer client impl
+ * - own gateway url
+ */
 
+/**
+ * default readState that works OOTB
+ * - Uses PouchDB to cache interactions
+ * - Uses Warp Sequencer
+ * - Use arweave.net gateway
+ */
 export const readState = readStateWith({
   fetch,
   GATEWAY_URL,
-  SEQUENCER_URL,
-  dbClient,
+  sequencer: sequencerClientSchema.parse({
+    loadInteractions: loadInteractionsWith({ fetch, SEQUENCER_URL }),
+    writeInteraction: writeInteractionWith({ fetch, SEQUENCER_URL }),
+  }),
+  db: dbClientSchema.parse({ findLatestInteraction, saveInteraction }),
 });
 
+/**
+ * default writeInteraction that works OOTB
+ * - Uses Warp Sequencer
+ * - Use arweave.net gateway
+ */
 export const writeInteraction = writeInteractionWith({
   fetch,
-  SEQUENCER_URL,
+  GATEWAY_URL,
+  sequencer: sequencerClientSchema.parse({
+    loadInteractions: loadInteractionsWith({ fetch, SEQUENCER_URL }),
+    writeInteraction: writeInteractionWith({ fetch, SEQUENCER_URL }),
+  }),
 });

--- a/sdk/src/lib/evaluate.test.js
+++ b/sdk/src/lib/evaluate.test.js
@@ -4,7 +4,6 @@ import { readFileSync } from "node:fs";
 import { Resolved } from "hyper-async";
 
 import { evaluateWith } from "./evaluate.js";
-import { cachedInteractionSchema } from "../dal.js";
 
 describe("evaluate", () => {
   test("evaluate state and add output to context", async () => {
@@ -13,9 +12,7 @@ describe("evaluate", () => {
       db: {
         saveInteraction: (interaction) => {
           cacheCount++;
-          const res = cachedInteractionSchema.safeParse(interaction);
-          assert.ok(res.success);
-          return Resolved(res.data);
+          return Resolved(interaction);
         },
       },
     };

--- a/sdk/src/main.test.js
+++ b/sdk/src/main.test.js
@@ -1,13 +1,29 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import * as pouchDb from "./client/pouchdb.js";
+import {
+  loadInteractionsWith,
+  writeInteractionWith,
+} from "./client/warp-sequencer.js";
+
 const GATEWAY_URL = globalThis.GATEWAY || "https://arweave.net";
 const SEQUENCER_URL = globalThis.SEQUENCER_URL || "https://gw.warp.cc";
 const CONTRACT = "zc24Wpv_i6NNCEdxeKt7dcNrqL5w0hrShtSCcFGGL24";
 
 test("readState", async () => {
   const { readStateWith } = await import("./main.js");
-  const result = await readStateWith({ fetch, GATEWAY_URL, SEQUENCER_URL })(
+
+  const result = await readStateWith({
+    fetch,
+    GATEWAY_URL,
+    // TODO: we should stub these for the test
+    db: pouchDb,
+    sequencer: {
+      loadInteractions: loadInteractionsWith({ fetch, SEQUENCER_URL }),
+      writeInteraction: writeInteractionWith({ fetch, SEQUENCER_URL }),
+    },
+  })(
     CONTRACT,
   );
   console.log(result);


### PR DESCRIPTION
…ate OOTB impls for PouchDB and Warp from dal #20

This PR establishes a `db` and `sequencer` client shape to be used to wrap any impl, implemented as a zod schema that will parse the client and ensure it's correctness. OOTB, the sdk has a PouchDB impl for the `db` client and a Warp Sequencer client for the `sequencer` client. The OOTB clients have been moved into the `client` folder, so they're logically separated in the project, from the `dal` and `lib` business logic

This provides better safety and also enables us to later swap out `db` and `sequencer` impls as we see fit, without needing to change the underlying business logic of each step in the `readState` and `writeInteraction` pipeline.