### PR TITLE
feat(sdk): fetch multiple pages of interactions from sequencer if nec…

### DIFF
--- a/sdk/src/client/pouchdb.js
+++ b/sdk/src/client/pouchdb.js
@@ -159,7 +159,7 @@ export function saveEvaluationWith(
               // No cached document found
               if (err.status === 404) {
                 logger(
-                  `No cached document found with _id %s. Caching interaction %O`,
+                  `No cached document found with _id %s. Caching evaluation %O`,
                   doc._id,
                   doc,
                 );

--- a/sdk/src/client/warp-sequencer.test.js
+++ b/sdk/src/client/warp-sequencer.test.js
@@ -1,10 +1,12 @@
 import { describe, test } from "node:test";
 import * as assert from "node:assert";
 
+import { createLogger } from "../logger.js";
 import { loadInteractionsWith } from "./warp-sequencer.js";
 
 const SEQUENCER_URL = "https://gw.warp.cc";
 const CONTRACT = "SFKREVkacx7N64SIfAuNkMOPTocm42qbkKwzRJGfQHY";
+const logger = createLogger("@permaweb/ao-sdk:readState");
 
 describe("warp-sequencer", () => {
   describe("loadInteractions", () => {
@@ -12,6 +14,8 @@ describe("warp-sequencer", () => {
       const loadInteractions = loadInteractionsWith({
         fetch,
         SEQUENCER_URL,
+        logger: logger.child("readState:sequencer"),
+        pageSize: 2500
       });
 
       const res = await loadInteractions({

--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -31,6 +31,8 @@ export const readState = readStateWith({
     loadInteractions: WarpSequencerClient.loadInteractionsWith({
       fetch,
       SEQUENCER_URL,
+      pageSize: 2500,
+      logger: logger.child("readState:sequencer"),
     }),
     writeInteraction: WarpSequencerClient.writeInteractionWith({
       fetch,
@@ -66,6 +68,8 @@ export const writeInteraction = writeInteractionWith({
     loadInteractions: WarpSequencerClient.loadInteractionsWith({
       fetch,
       SEQUENCER_URL,
+      pageSize: 2500,
+      logger: logger.child("writeInteraction:sequencer"),
     }),
     writeInteraction: WarpSequencerClient.writeInteractionWith({
       fetch,

--- a/sdk/src/index.test.js
+++ b/sdk/src/index.test.js
@@ -4,6 +4,10 @@ import assert from "node:assert/strict";
 import { readState } from "./index.js";
 
 const CONTRACT = "VkjFCALjk4xxuCilddKS8ShZ-9HdeqeuYQOgMgWucro";
+/**
+ * js contract, with lots of interactions. Good for debugging interactions bit
+ */
+// const CONTRACT = 'SFKREVkacx7N64SIfAuNkMOPTocm42qbkKwzRJGfQHY'
 
 test("readState", async () => {
   const result = await readState(CONTRACT);

--- a/sdk/src/main.js
+++ b/sdk/src/main.js
@@ -85,9 +85,9 @@ export function readStateWith(
       .map((ctx) => ctx.output)
       .map(
         logger.tap(
-          `readState result for contract ${contractId} to sortKey ${
-            sortKeyHeight || "latest"
-          }: %O`,
+          `readState result for contract "%s" to sortKey "%s": %O`,
+          contractId,
+          sortKeyHeight || "latest",
         ),
       )
       .toPromise();

--- a/sdk/src/main.test.js
+++ b/sdk/src/main.test.js
@@ -33,7 +33,7 @@ test("readState", async () => {
       }),
     },
     sequencer: {
-      loadInteractions: loadInteractionsWith({ fetch, SEQUENCER_URL }),
+      loadInteractions: loadInteractionsWith({ fetch, SEQUENCER_URL, logger, pageSize: 2500 }),
       writeInteractionWith: writeInteractionWith({ fetch, SEQUENCER_URL }),
     },
     logger,


### PR DESCRIPTION
…essary #37

Closes #37 

This PR makes so the Warp Sequencer client can fetch multiple pages of interactions from the Warp Sequencer, if necessary, to perform an evaluation.