### PR TITLE
fix(dev-cli): remove trailing slash in volume mount

### DIFF
--- a/dev-cli/src/commands/build.js
+++ b/dev-cli/src/commands/build.js
@@ -1,4 +1,5 @@
 export async function build() {
+  const pwd = Deno.cwd()
   const p = Deno.run({
     cmd: [
       "docker",
@@ -6,7 +7,7 @@ export async function build() {
       "--platform",
       "linux/amd64",
       "-v",
-      "${PWD}:/src",
+      `${pwd}:/src`,
       "p3rmaw3b/ao",
       "emcc-lua",
     ],

--- a/dev-cli/src/commands/repl.js
+++ b/dev-cli/src/commands/repl.js
@@ -1,4 +1,5 @@
 export async function repl() {
+  const pwd = Deno.cwd()
   const p = Deno.run({
     cmd: [
       "docker",
@@ -6,7 +7,7 @@ export async function repl() {
       "--platform",
       "linux/amd64",
       "-v",
-      "${PWD}:/src",
+      `${pwd}:/src`,
       "-it",
       "p3rmaw3b/ao",
       "lua",

--- a/dev-cli/src/commands/run.js
+++ b/dev-cli/src/commands/run.js
@@ -1,4 +1,5 @@
 export async function run(_, f) {
+  const pwd = Deno.cwd()
   const p = Deno.run({
     cmd: [
       "docker",
@@ -6,7 +7,7 @@ export async function run(_, f) {
       "--platform",
       "linux/amd64",
       "-v",
-      "${PWD}:/src",
+      `${pwd}:/src`,
       "-a",
       "stdout",
       "-a",


### PR DESCRIPTION
Looking at #57

looking at #57 again, I don't think `${PWD}/` is right. I think we need to remove the trailing `/`

