### PR TITLE
refactor(sdk): enforce contracts in BL instead of entrypoint and use contracts in all tests to assert correct stubs

### DIFF
--- a/sdk/src/client/ao-mu.test.js
+++ b/sdk/src/client/ao-mu.test.js
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
 
 import { createLogger } from '../logger.js'
+import { deployInteractionSchema, signerSchema } from '../dal.js'
 import { deployInteractionWith } from './ao-mu.js'
 
 const MU_URL = globalThis.MU_URL || 'https://ao-mu-1.onrender.com'
@@ -10,40 +11,44 @@ const logger = createLogger('@permaweb/ao-sdk:readState')
 describe('ao-mu', () => {
   describe('deployInteractionWith', () => {
     test('sign and deploy the contract, and return the id', async () => {
-      const deployInteraction = deployInteractionWith({
-        MU_URL,
-        logger,
-        fetch: async (url, options) => {
-          assert.equal(url, `${MU_URL}/write`)
-          assert.deepStrictEqual(options, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json'
-            },
-            body: JSON.stringify({
-              cid: 'contract-asdf',
-              txid: 'data-item-123',
-              data: 'raw-buffer'
+      const deployInteraction = deployInteractionSchema.implement(
+        deployInteractionWith({
+          MU_URL,
+          logger,
+          fetch: async (url, options) => {
+            assert.equal(url, `${MU_URL}/write`)
+            assert.deepStrictEqual(options, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json'
+              },
+              body: JSON.stringify({
+                cid: 'contract-asdf',
+                txid: 'data-item-123',
+                data: 'raw-buffer'
+              })
             })
-          })
 
-          return new Response(JSON.stringify({ message: 'foobar' }))
-        }
-      })
+            return new Response(JSON.stringify({ message: 'foobar' }))
+          }
+        })
+      )
 
       const res = await deployInteraction({
         contractId: 'contract-asdf',
         data: 'data-123',
-        signer: async ({ data, tags }) => {
-          assert.ok(data)
-          assert.deepStrictEqual(tags, [
-            { name: 'foo', value: 'bar' },
-            { name: 'Content-Type', value: 'text/plain' }
-          ])
+        signer: signerSchema.implement(
+          async ({ data, tags }) => {
+            assert.ok(data)
+            assert.deepStrictEqual(tags, [
+              { name: 'foo', value: 'bar' },
+              { name: 'Content-Type', value: 'text/plain' }
+            ])
 
-          return { id: 'data-item-123', raw: 'raw-buffer' }
-        },
+            return { id: 'data-item-123', raw: 'raw-buffer' }
+          }
+        ),
         tags: [
           { name: 'foo', value: 'bar' },
           { name: 'Content-Type', value: 'text/plain' }

--- a/sdk/src/client/warp-gateway.test.js
+++ b/sdk/src/client/warp-gateway.test.js
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
 
 import { createLogger } from '../logger.js'
+import { deployContractSchema, signerSchema } from '../dal.js'
 import { deployContractWith } from './warp-gateway.js'
 
 const WARP_GATEWAY_URL = globalThis.WARP_GATEWAY_URL || 'https://gw.warp.cc'
@@ -10,31 +11,35 @@ const logger = createLogger('@permaweb/ao-sdk:readState')
 describe('warp-gateway', () => {
   describe('deplyContractsWith', () => {
     test('sign and deploy the contract, and return the id', async () => {
-      const deployContract = deployContractWith({
-        WARP_GATEWAY_URL,
-        logger,
-        fetch: async (url, options) => {
-          assert.equal(url, `${WARP_GATEWAY_URL}/gateway/v2/contracts/deploy`)
-          assert.deepStrictEqual(options, {
-            method: 'POST',
-            headers: {
-              'Accept-Encoding': 'gzip, deflate, br',
-              'Content-Type': 'application/json',
-              Accept: 'application/json'
-            },
-            body: JSON.stringify({
-              contract: 'raw-buffer'
+      const deployContract = deployContractSchema.implement(
+        deployContractWith({
+          WARP_GATEWAY_URL,
+          logger,
+          fetch: async (url, options) => {
+            assert.equal(url, `${WARP_GATEWAY_URL}/gateway/v2/contracts/deploy`)
+            assert.deepStrictEqual(options, {
+              method: 'POST',
+              headers: {
+                'Accept-Encoding': 'gzip, deflate, br',
+                'Content-Type': 'application/json',
+                Accept: 'application/json'
+              },
+              body: JSON.stringify({
+                contract: 'raw-buffer'
+              })
             })
-          })
 
-          return new Response(JSON.stringify({ contractTxId: 'bar-tx-123', foo: 'bar' }))
-        }
-      })
+            return new Response(JSON.stringify({ contractTxId: 'bar-tx-123', foo: 'bar' }))
+          }
+        })
+      )
 
       const res = await deployContract({
         data: '1234',
         tags: [],
-        signer: async () => ({ id: 'data-item-123', raw: 'raw-buffer' })
+        signer: signerSchema.implement(
+          async () => ({ id: 'data-item-123', raw: 'raw-buffer' })
+        )
       })
 
       assert.deepStrictEqual(res, {
@@ -45,12 +50,14 @@ describe('warp-gateway', () => {
 
     test('replace the SDK tag and add a Nonce tag', async () => {
       const time = new Date().getTime()
-      const deployContract = deployContractWith({
-        WARP_GATEWAY_URL,
-        logger,
-        fetch: async (url, options) => new Response(JSON.stringify({ foo: 'bar' })),
-        getTime: () => time
-      })
+      const deployContract = deployContractSchema.implement(
+        deployContractWith({
+          WARP_GATEWAY_URL,
+          logger,
+          fetch: async (url, options) => new Response(JSON.stringify({ contractTxId: 'bar-tx-123', foo: 'bar' })),
+          getTime: () => time
+        })
+      )
 
       await deployContract({
         data: '1234',
@@ -59,17 +66,19 @@ describe('warp-gateway', () => {
           { name: 'SDK', value: 'ao' },
           { name: 'Content-Type', value: 'text/plain' }
         ],
-        signer: async ({ data, tags }) => {
-          assert.ok(data)
-          assert.deepStrictEqual(tags, [
-            { name: 'foo', value: 'bar' },
-            { name: 'Content-Type', value: 'text/plain' },
-            { name: 'SDK', value: 'Warp' },
-            { name: 'Nonce', value: `${time}` }
-          ])
+        signer: signerSchema.implement(
+          async ({ data, tags }) => {
+            assert.ok(data)
+            assert.deepStrictEqual(tags, [
+              { name: 'foo', value: 'bar' },
+              { name: 'Content-Type', value: 'text/plain' },
+              { name: 'SDK', value: 'Warp' },
+              { name: 'Nonce', value: `${time}` }
+            ])
 
-          return { id: 'contract-id-123', raw: 'raw-buffer' }
-        }
+            return { id: 'contract-id-123', raw: 'raw-buffer' }
+          }
+        )
       })
     })
   })

--- a/sdk/src/dal.js
+++ b/sdk/src/dal.js
@@ -1,23 +1,64 @@
 import { z } from 'zod'
 
+const tagSchema = z.object({
+  name: z.string(),
+  value: z.string()
+})
+
 export const loadStateSchema = z.function()
   .args(z.object({
     id: z.string().min(1, { message: 'contract id is required' }),
     sortKey: z.string().optional()
   }))
   .returns(
-    z.promise(z.record(z.any()))
+    z.promise(z.any())
   )
 
-// TODO: define this shape
 export const deployInteractionSchema = z.function()
-  .args(z.record(z.any()))
-  .returns(z.promise(z.any()))
+  .args(z.object({
+    contractId: z.string(),
+    data: z.any(),
+    tags: z.array(tagSchema),
+    signer: z.any()
+  }))
+  .returns(z.promise(
+    z.object({
+      interactionId: z.string()
+    }).passthrough()
+  ))
+
+export const deployContractSchema = z.function()
+  .args(z.object({
+    data: z.any(),
+    tags: z.array(tagSchema),
+    signer: z.any()
+  }))
+  .returns(z.promise(
+    z.object({
+      contractId: z.string()
+    }).passthrough()
+  ))
 
 export const loadTransactionMetaSchema = z.function()
   .args(z.string())
-  .returns(z.promise(z.any()))
+  .returns(z.promise(
+    z.object({
+      tags: z.array(tagSchema)
+    }).passthrough()
+  ))
 
 export const loadTransactionDataSchema = z.function()
   .args(z.string())
   .returns(z.promise(z.any()))
+
+export const signerSchema = z.function()
+  .args(z.object({
+    data: z.any(),
+    tags: z.array(tagSchema)
+  }))
+  .returns(z.promise(
+    z.object({
+      id: z.string(),
+      raw: z.any()
+    })
+  ))

--- a/sdk/src/index.common.js
+++ b/sdk/src/index.common.js
@@ -1,10 +1,3 @@
-import { fromPromise } from 'hyper-async'
-
-import {
-  loadStateSchema,
-  deployInteractionSchema,
-  loadTransactionMetaSchema
-} from './dal.js'
 import { createLogger } from './logger.js'
 
 import * as MuClient from './client/ao-mu.js'
@@ -34,9 +27,7 @@ const readStateLogger = logger.child('readState')
  */
 export function buildSdk () {
   const readState = readStateWith({
-    loadState: fromPromise(
-      loadStateSchema.implement(CuClient.loadStateWith({ fetch, CU_URL, logger: readStateLogger }))
-    ),
+    loadState: CuClient.loadStateWith({ fetch, CU_URL, logger: readStateLogger }),
     logger: readStateLogger
   })
 
@@ -47,16 +38,8 @@ export function buildSdk () {
    */
   const writeInteractionLogger = logger.child('writeInteraction')
   const writeInteraction = writeInteractionWith({
-    loadTransactionMeta: fromPromise(
-      loadTransactionMetaSchema.implement(
-        GatewayClient.loadTransactionMetaWith({ fetch, GATEWAY_URL })
-      )
-    ),
-    deployInteraction: fromPromise(
-      deployInteractionSchema.implement(
-        MuClient.deployInteractionWith({ fetch, MU_URL, logger: writeInteractionLogger })
-      )
-    ),
+    loadTransactionMeta: GatewayClient.loadTransactionMetaWith({ fetch, GATEWAY_URL }),
+    deployInteraction: MuClient.deployInteractionWith({ fetch, MU_URL, logger: writeInteractionLogger }),
     logger: writeInteractionLogger
   })
 
@@ -67,14 +50,8 @@ export function buildSdk () {
    */
   const createContractLogger = logger.child('createContract')
   const createContract = createContractWith({
-    loadTransactionMeta: fromPromise(
-      loadTransactionMetaSchema.implement(
-        GatewayClient.loadTransactionMetaWith({ fetch, GATEWAY_URL })
-      )
-    ),
-    deployContract: fromPromise(
-      WarpGatewayClient.deployContractWith({ fetch, WARP_GATEWAY_URL, logger: createContractLogger })
-    ),
+    loadTransactionMeta: GatewayClient.loadTransactionMetaWith({ fetch, GATEWAY_URL }),
+    deployContract: WarpGatewayClient.deployContractWith({ fetch, WARP_GATEWAY_URL, logger: createContractLogger }),
     logger: createContractLogger
   })
 

--- a/sdk/src/lib/createContract/upload-contract.test.js
+++ b/sdk/src/lib/createContract/upload-contract.test.js
@@ -1,8 +1,6 @@
 import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
 
-import { Resolved } from 'hyper-async'
-
 import { createLogger } from '../../logger.js'
 import { uploadContractWith } from './upload-contract.js'
 
@@ -11,7 +9,7 @@ const logger = createLogger('createContract')
 describe('upload-contract', () => {
   test('add the tags, sign, upload the contract, and return the contractId', async () => {
     const uploadContract = uploadContractWith({
-      deployContract: ({ data, tags, signer }) => {
+      deployContract: async ({ data, tags, signer }) => {
         assert.ok(data)
         assert.deepStrictEqual(tags, [
           { name: 'foo', value: 'bar' },
@@ -24,7 +22,7 @@ describe('upload-contract', () => {
         ])
         assert.ok(signer)
 
-        return Resolved({ contractId: 'contract-id-123' })
+        return { res: 'foobar', contractId: 'contract-id-123' }
       },
       logger
     })
@@ -38,5 +36,29 @@ describe('upload-contract', () => {
       signer: async () => ({ id: 'contract-id-123', raw: 'raw-buffer' })
     }).toPromise()
       .then(res => assert.equal(res.contractId, 'contract-id-123'))
+  })
+
+  test('defaults tags if none are provided', async () => {
+    const uploadContract = uploadContractWith({
+      deployContract: async ({ tags }) => {
+        assert.deepStrictEqual(tags, [
+          { name: 'App-Name', value: 'SmartWeaveContract' },
+          { name: 'App-Version', value: '0.3.0' },
+          { name: 'Content-Type', value: 'text/plain' },
+          { name: 'Init-State', value: JSON.stringify({ initial: 'state' }) },
+          { name: 'Contract-Src', value: 'src-id-123' },
+          { name: 'SDK', value: 'ao' }
+        ])
+
+        return { res: 'foobar', contractId: 'contract-id-123' }
+      },
+      logger
+    })
+
+    await uploadContract({
+      srcId: 'src-id-123',
+      initialState: { initial: 'state' },
+      signer: async () => ({ id: 'contract-id-123', raw: 'raw-buffer' })
+    }).toPromise()
   })
 })

--- a/sdk/src/lib/createContract/verify-inputs.js
+++ b/sdk/src/lib/createContract/verify-inputs.js
@@ -1,6 +1,8 @@
-import { Rejected, Resolved, of } from 'hyper-async'
+import { Rejected, Resolved, fromPromise, of } from 'hyper-async'
 import { z } from 'zod'
 import { assoc, equals, prop, reduce } from 'ramda'
+
+import { loadTransactionMetaSchema } from '../../dal.js'
 
 /**
  * @typedef Tag
@@ -22,7 +24,7 @@ function verifySourceWith ({ loadTransactionMeta, logger }) {
     : Rejected(`Tag '${name}' of value '${tags[name]}' was not valid on contract source`)
 
   return (srcId) => of(srcId)
-    .chain(loadTransactionMeta)
+    .chain(fromPromise(loadTransactionMetaSchema.implement(loadTransactionMeta)))
     .map(prop('tags'))
     .map(reduce((a, t) => assoc(t.name, t.value, a), {}))
     .chain(checkTag('App-Name', equals('SmartWeaveContractSource')))

--- a/sdk/src/lib/createContract/verify-inputs.test.js
+++ b/sdk/src/lib/createContract/verify-inputs.test.js
@@ -1,8 +1,6 @@
 import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
 
-import { Resolved } from 'hyper-async'
-
 import { createLogger } from '../../logger.js'
 import { verifyInputsWith } from './verify-inputs.js'
 
@@ -13,8 +11,8 @@ const logger = createLogger('createContract')
 describe('verify-input', () => {
   test('verify source tags and verify signer', async () => {
     const verifyInput = verifyInputsWith({
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'App-Name', value: 'SmartWeaveContractSource' },
             { name: 'Content-Type', value: 'application/wasm' },
@@ -36,8 +34,8 @@ describe('verify-input', () => {
 
   test('throw if source is missing correct App-Name', async () => {
     const verifyInput = verifyInputsWith({
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'App-Name', value: 'NotRightValue' },
             { name: 'Content-Type', value: 'application/wasm' },
@@ -66,8 +64,8 @@ describe('verify-input', () => {
 
   test('throw if missing Content-Type', async () => {
     const verifyInput = verifyInputsWith({
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'App-Name', value: 'SmartWeaveContractSource' },
             { name: 'No-Content-Type', value: 'application/wasm' },
@@ -96,8 +94,8 @@ describe('verify-input', () => {
 
   test('throw if missing Content-Type', async () => {
     const verifyInput = verifyInputsWith({
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'App-Name', value: 'SmartWeaveContractSource' },
             { name: 'Content-Type', value: 'application/wasm' },
@@ -126,8 +124,8 @@ describe('verify-input', () => {
 
   test('throw if signer is not found', async () => {
     const verifyInput = verifyInputsWith({
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'App-Name', value: 'SmartWeaveContractSource' },
             { name: 'Content-Type', value: 'application/wasm' },
@@ -157,8 +155,8 @@ describe('verify-input', () => {
 
   test('throw if initial state is not an object', async () => {
     const verifyInput = verifyInputsWith({
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'App-Name', value: 'SmartWeaveContractSource' },
             { name: 'Content-Type', value: 'application/wasm' },

--- a/sdk/src/lib/readState/read.js
+++ b/sdk/src/lib/readState/read.js
@@ -1,5 +1,7 @@
-import { of } from 'hyper-async'
+import { fromPromise, of } from 'hyper-async'
 import { defaultTo, pipe, prop } from 'ramda'
+
+import { loadStateSchema } from '../../dal.js'
 
 /**
  * @typedef Env
@@ -19,7 +21,9 @@ import { defaultTo, pipe, prop } from 'ramda'
 export function readWith (env) {
   return (ctx) => {
     return of({ id: ctx.id, sortKey: ctx.sortKey })
-      .chain(env.loadState)
+      .chain(fromPromise(
+        loadStateSchema.implement(env.loadState)
+      ))
       .map(pipe(
         defaultTo({}),
         prop('state')

--- a/sdk/src/lib/readState/read.test.js
+++ b/sdk/src/lib/readState/read.test.js
@@ -2,18 +2,17 @@ import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
 
 import { readWith } from './read.js'
-import { Resolved } from 'hyper-async'
 
 describe('read', () => {
   test('should return the loaded state', async () => {
     const read = readWith({
-      loadState: (args) => {
+      loadState: async (args) => {
         assert.deepStrictEqual(args, {
           id: 'contract-123',
           sortKey: 'sort-key-123'
         })
 
-        return Resolved({ state: { foo: 'bar' } })
+        return { state: { foo: 'bar' } }
       }
     })
 
@@ -25,7 +24,7 @@ describe('read', () => {
 
   test('should return undefined if no state', async () => {
     const read = readWith({
-      loadState: (args) => Resolved({ no_state: { foo: 'bar' } })
+      loadState: async (args) => ({ no_state: { foo: 'bar' } })
     })
 
     await read({
@@ -37,7 +36,7 @@ describe('read', () => {
 
   test('should return undefined if no value', async () => {
     const read = readWith({
-      loadState: (args) => Resolved(undefined)
+      loadState: async (args) => undefined
     })
 
     await read({

--- a/sdk/src/lib/writeInteraction/upload-interaction.test.js
+++ b/sdk/src/lib/writeInteraction/upload-interaction.test.js
@@ -1,13 +1,12 @@
 import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
-import { Resolved } from 'hyper-async'
 
 import { uploadInteractionWith } from './upload-interaction.js'
 
 describe('upload-interaction', () => {
-  test('add the tafs, sign, and upload the interaction, and return the interactionId', async () => {
+  test('add the tags, sign, and upload the interaction, and return the interactionId', async () => {
     const uploadInteraction = uploadInteractionWith({
-      deployInteraction: ({ contractId, data, tags, signer }) => {
+      deployInteraction: async ({ contractId, data, tags, signer }) => {
         assert.ok(data)
         assert.equal(contractId, 'contract-asdf')
         assert.deepStrictEqual(tags, [
@@ -20,7 +19,7 @@ describe('upload-interaction', () => {
         ])
         assert.ok(signer)
 
-        return Resolved({ interactionId: 'data-item-123' })
+        return { interactionId: 'data-item-123' }
       }
     })
 

--- a/sdk/src/lib/writeInteraction/verify-contract.js
+++ b/sdk/src/lib/writeInteraction/verify-contract.js
@@ -1,6 +1,8 @@
-import { of } from 'hyper-async'
+import { fromPromise, of } from 'hyper-async'
 import { assoc, path, reduce } from 'ramda'
 import { z } from 'zod'
+
+import { loadTransactionMetaSchema } from '../../dal.js'
 
 const transactionSchema = z.object({
   tags: z.array(z.object({
@@ -30,7 +32,8 @@ const contractTagsSchema = z.object({
  */
 function verfiyTagsWith ({ loadTransactionMeta }) {
   return (id) => {
-    return loadTransactionMeta(id)
+    return of(id)
+      .chain(fromPromise(loadTransactionMetaSchema.implement(loadTransactionMeta)))
       .map(transactionSchema.parse)
       .map(path(['tags']))
       .map(reduce((a, t) => assoc(t.name, t.value, a), {}))

--- a/sdk/src/lib/writeInteraction/verify-contract.test.js
+++ b/sdk/src/lib/writeInteraction/verify-contract.test.js
@@ -2,17 +2,14 @@ import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
 
 import { verifyContractWith } from './verify-contract.js'
-import { Resolved } from 'hyper-async'
 
 const CONTRACT = 'zc24Wpv_i6NNCEdxeKt7dcNrqL5w0hrShtSCcFGGL24'
 
 describe('verify-contract', () => {
   test('verify contract is a smartweave contract', async () => {
     const verifyContract = verifyContractWith({
-      loadTransactionData: (_id) =>
-        Resolved(new Response(JSON.stringify({ hello: 'world' }))),
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'Contract-Src', value: 'foobar' },
             { name: 'App-Name', value: 'SmartWeaveContract' },
@@ -28,10 +25,8 @@ describe('verify-contract', () => {
 
   test('throw if the Contract-Src tag is not provided', async () => {
     const verifyContract = verifyContractWith({
-      loadTransactionData: (_id) =>
-        Resolved(new Response(JSON.stringify({ hello: 'world' }))),
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'App-Name', value: 'SmartWeaveContract' },
             { name: 'App-Version', value: '0.3.0' }
@@ -46,10 +41,8 @@ describe('verify-contract', () => {
 
   test('throw if the App-Name tag is not provided', async () => {
     const verifyContract = verifyContractWith({
-      loadTransactionData: (_id) =>
-        Resolved(new Response(JSON.stringify({ hello: 'world' }))),
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'Contract-Src', value: 'foobar' },
             { name: 'App-Version', value: '0.3.0' }
@@ -64,10 +57,8 @@ describe('verify-contract', () => {
 
   test('throw if multiple tags not provided', async () => {
     const verifyContract = verifyContractWith({
-      loadTransactionData: (_id) =>
-        Resolved(new Response(JSON.stringify({ hello: 'world' }))),
-      loadTransactionMeta: (_id) =>
-        Resolved({
+      loadTransactionMeta: async (_id) =>
+        ({
           tags: [
             { name: 'App-Version', value: '0.3.0' }
           ]


### PR DESCRIPTION
Now the BL enforces the contracts with side effects instead of the entrypoints, then we also use the contracts in our client impl test to assert of client impls satisfy the business contract at test time.

This gives us much more confidence that BL is correct