### PR TITLE
feat(ao-cli): ao build accept multiple files #120

### DIFF
--- a/dev-cli/container/src/emcc-lua
+++ b/dev-cli/container/src/emcc-lua
@@ -66,13 +66,13 @@ def main():
     local_include_prefix_re = re.compile(re.escape(local_include_dir + '/'))
 
     # Detect bundles
-    bundle_files = [os.path.abspath('contract.lua')]
+    bundle_files = glob.glob('/src/**/*.lua', recursive=True)
+    
     # Optional dependencies
     bundle_files += glob.glob(local_include_dir + '/**/*.lua', recursive=True)
     bundle_files += glob.glob(local_include_dir + '/**/*.so', recursive=True)
     bundle_files += glob.glob(LUAROCKS_LOCAL_MODULE_DIR + '/lib/lua/**/*.so', recursive=True)
     bundle_files += glob.glob(LUAROCKS_LOCAL_MODULE_DIR + '/share/lua/**/*.lua', recursive=True)
-
     debug_print('Start to factory and distinguish module files')
 
     for bundle in bundle_files:


### PR DESCRIPTION
This PR, updates the build script to support adding multiple `lua` files to the wasm process. Since the compiler is running inside docker you have to require your files using the convention that they will be bundled. All files in your current directory are located in the `/src/` folder of the docker container. 

To properly require you files, you need to do the following:

```lua
local foo = require(".src.foo")
```

In lua, the dots represent slashes, so "/src/foo.lua" is represented by ".src.foo". If you create a folder in your dev environment, then you will need to create that representation in your lua file.

File: `/src/lib/bar.lua`

```lua
local bar = require(".src.lib.bar")
```

