### PR TITLE
fix(sdk): load process meta from SU to prevent race condition on gateway

### DIFF
--- a/sdk/src/client/ao-su.js
+++ b/sdk/src/client/ao-su.js
@@ -55,3 +55,10 @@ export function deployProcessWith ({ fetch, SU_URL, logger: _logger }) {
       .toPromise()
   }
 }
+
+export const loadProcessMetaWith = ({ fetch, SU_URL }) => {
+  return async (processId) => {
+    return fetch(`${SU_URL}/processes/${processId}`, { method: 'GET' })
+      .then(res => res.json())
+  }
+}

--- a/sdk/src/client/ao-su.test.js
+++ b/sdk/src/client/ao-su.test.js
@@ -2,8 +2,8 @@ import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
 
 import { createLogger } from '../logger.js'
-import { deployProcessWith } from './ao-su.js'
-import { deployProcessSchema, signerSchema } from '../dal.js'
+import { deployProcessWith, loadProcessMetaWith } from './ao-su.js'
+import { deployProcessSchema, loadProcessMetaSchema, signerSchema } from '../dal.js'
 
 const SU_URL = globalThis.SU_URL || 'https://su.foo'
 const logger = createLogger('@permaweb/ao-sdk:createProcess')
@@ -44,6 +44,34 @@ describe('ao-su', () => {
           }
         )
       })
+    })
+  })
+
+  describe('loadProcessMeta', () => {
+    test('return the process meta', async () => {
+      const tags = [
+        {
+          name: 'Contract-Src',
+          value: 'gnVg6A6S8lfB10P38V7vOia52lEhTX3Uol8kbTGUT8w'
+        },
+        {
+          name: 'SDK',
+          value: 'ao'
+        }
+      ]
+
+      const loadProcessMeta = loadProcessMetaSchema.implement(
+        loadProcessMetaWith({
+          SU_URL,
+          fetch: async (url) => {
+            assert.equal(url, `${SU_URL}/processes/uPKuZ6SABUXvgaEL3ZS3ku5QR1RLwE70V6IUslmZJFI`)
+            return new Response(JSON.stringify({ tags }))
+          }
+        }))
+
+      const res = await loadProcessMeta('uPKuZ6SABUXvgaEL3ZS3ku5QR1RLwE70V6IUslmZJFI')
+
+      assert.deepStrictEqual(res, { tags })
     })
   })
 })

--- a/sdk/src/client/gateway.js
+++ b/sdk/src/client/gateway.js
@@ -66,24 +66,3 @@ export function loadTransactionMetaWith ({ fetch, GATEWAY_URL }) {
       ))
       .toPromise()
 }
-
-/**
-   * @typedef Env2
-   * @property {fetch} fetch
-   * @property {string} GATEWAY_URL
-   *
-   * @callback LoadTransactionData
-   * @param {string} id - the id of the transaction whose data is being loaded
-   * @returns {Async<Response>}
-   *
-   * @param {Env2} env
-   * @returns {LoadTransactionData}
-   */
-export function loadTransactionDataWith ({ fetch, GATEWAY_URL }) {
-  // TODO: create a dataloader and use that to batch load contracts
-
-  return (id) =>
-    of(id)
-      .chain(fromPromise((id) => fetch(`${GATEWAY_URL}/${id}`)))
-      .toPromise()
-}

--- a/sdk/src/client/gateway.test.js
+++ b/sdk/src/client/gateway.test.js
@@ -1,8 +1,8 @@
 import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
 
-import { loadTransactionDataSchema, loadTransactionMetaSchema } from '../dal.js'
-import { loadTransactionDataWith, loadTransactionMetaWith } from './gateway.js'
+import { loadTransactionMetaSchema } from '../dal.js'
+import { loadTransactionMetaWith } from './gateway.js'
 
 const GATEWAY_URL = globalThis.GATEWAY || 'https://arweave.net'
 const PROCESS = 'zc24Wpv_i6NNCEdxeKt7dcNrqL5w0hrShtSCcFGGL24'
@@ -58,22 +58,6 @@ describe('gateway', () => {
         }))
 
       await loadTransactionMeta(PROCESS)
-    })
-  })
-
-  describe('loadTransactionDataWith', () => {
-    test('load transaction data', async () => {
-      const loadTransactionData = loadTransactionDataSchema.implement(
-        loadTransactionDataWith({
-          fetch,
-          GATEWAY_URL
-        })
-      )
-      const result = await loadTransactionData(PROCESS)
-      assert.ok(result.arrayBuffer)
-      assert.ok(result.json)
-      assert.ok(result.text)
-      assert.ok(result.ok)
     })
   })
 })

--- a/sdk/src/dal.js
+++ b/sdk/src/dal.js
@@ -5,6 +5,8 @@ const tagSchema = z.object({
   value: z.string()
 })
 
+// CU
+
 export const loadStateSchema = z.function()
   .args(z.object({
     id: z.string().min(1, { message: 'process id is required' }),
@@ -13,6 +15,8 @@ export const loadStateSchema = z.function()
   .returns(
     z.promise(z.any())
   )
+
+// MU
 
 export const deployMessageSchema = z.function()
   .args(z.object({
@@ -28,6 +32,8 @@ export const deployMessageSchema = z.function()
     }).passthrough()
   ))
 
+// SU
+
 export const deployProcessSchema = z.function()
   .args(z.object({
     data: z.any(),
@@ -40,7 +46,7 @@ export const deployProcessSchema = z.function()
     }).passthrough()
   ))
 
-export const loadTransactionMetaSchema = z.function()
+export const loadProcessMetaSchema = z.function()
   .args(z.string())
   .returns(z.promise(
     z.object({
@@ -48,9 +54,14 @@ export const loadTransactionMetaSchema = z.function()
     }).passthrough()
   ))
 
-export const loadTransactionDataSchema = z.function()
+// Gateway
+export const loadTransactionMetaSchema = z.function()
   .args(z.string())
-  .returns(z.promise(z.any()))
+  .returns(z.promise(
+    z.object({
+      tags: z.array(tagSchema)
+    }).passthrough()
+  ))
 
 export const signerSchema = z.function()
   .args(z.object({

--- a/sdk/src/index.common.js
+++ b/sdk/src/index.common.js
@@ -34,7 +34,7 @@ export function buildSdk () {
    */
   const writeMessageLogger = logger.child('writeMessage')
   const writeMessage = writeMessageWith({
-    loadTransactionMeta: GatewayClient.loadTransactionMetaWith({ fetch, GATEWAY_URL }),
+    loadProcessMeta: SuClient.loadProcessMetaWith({ fetch, SU_URL }),
     deployMessage: MuClient.deployMessageWith({ fetch, MU_URL, logger: writeMessageLogger }),
     logger: writeMessageLogger
   })

--- a/sdk/src/lib/writeMessage/verify-process.test.js
+++ b/sdk/src/lib/writeMessage/verify-process.test.js
@@ -8,7 +8,7 @@ const PROCESS = 'zc24Wpv_i6NNCEdxeKt7dcNrqL5w0hrShtSCcFGGL24'
 describe('verify-process', () => {
   test('verify process is an ao process', async () => {
     const verifyProcess = verifyProcessWith({
-      loadTransactionMeta: async (_id) =>
+      loadProcessMeta: async (_id) =>
         ({
           tags: [
             { name: 'Contract-Src', value: 'foobar' },
@@ -27,7 +27,7 @@ describe('verify-process', () => {
 
   test('throw if the Contract-Src tag is not provided', async () => {
     const verifyProcess = verifyProcessWith({
-      loadTransactionMeta: async (_id) =>
+      loadProcessMeta: async (_id) =>
         ({
           tags: [
             { name: 'Data-Protocol', value: 'ao' },
@@ -42,7 +42,7 @@ describe('verify-process', () => {
 
   test('throw if the Data-Protocol tag is not provided', async () => {
     const verifyProcess = verifyProcessWith({
-      loadTransactionMeta: async (_id) =>
+      loadProcessMeta: async (_id) =>
         ({
           tags: [
             { name: 'Contract-Src', value: 'foobar' },
@@ -57,7 +57,7 @@ describe('verify-process', () => {
 
   test('throw if multiple tags not provided', async () => {
     const verifyProcess = verifyProcessWith({
-      loadTransactionMeta: async (_id) =>
+      loadProcessMeta: async (_id) =>
         ({
           tags: [
             { name: 'Data-Protocol', value: 'ao' }


### PR DESCRIPTION
There was an issue when using the `writeMessage` api right after `createProcess` where the process metadata ie. `tags` were not present on the gateway. There seems to be only a small delay, less than 1 second, but it enough to cause a race condition in `writeMessage`, as part of verifying the process that the message is being written to.

This PR makes it so the SDK fetches the process meta from the SU instead of the gateway, which should eliminate the race condition, since the process is sequenced by the SU, as part of process creation via the SDK.

> The SDK is still currently using the gateway to fetch process _source_ metadata, as part of verifying tags on the process source, when creating a process.