### PR TITLE
perf(mu): separate forwarding message to su and cranking that message #155

### DIFF
--- a/servers/mu/src/routes/message.js
+++ b/servers/mu/src/routes/message.js
@@ -12,36 +12,32 @@ export const withMessageRoutes = (app) => {
         const {
           body,
           logger,
-          domain: { apis: { initMsgs, crankMsgs } }
+          domain: { apis: { sendMsg } }
         } = req
 
         if (!body) return res.status(400).send('Signed data item is required')
 
         /**
-         * Passively process the messages
+         * Forward the message
          */
         of({ raw: body })
-          .chain(initMsgs)
+          .chain(sendMsg)
           .bimap(
             logger.tap('Failed to forward initial message to the SU and read result from the CU'),
             logger.tap('Successfully forwarded initial message to the SU and read result from the CU. Beginning to crank...')
           )
-          .map(response => {
+          .chain(({ tx, crank: crankIt }) => {
             /**
              * Respond to the client after the initial message has been forwarded,
-             * then transparently continue cranking.
+             * then transparently continue cranking its results
              */
-            res.status(202).send({ message: 'Processing message', id: response.tx.id })
-            return response
+            res.status(202).send({ message: 'Processing message', id: tx.id })
+
+            return crankIt().bimap(
+              logger.tap('Failed to crank messages'),
+              logger.tap('Successfully cranked messages')
+            )
           })
-          .map(res => ({ msgs: res.msgs, spawns: res.spawns }))
-          .chain(res =>
-            crankMsgs(res)
-              .bimap(
-                logger.tap('Failed to crank messages'),
-                logger.tap('Successfully cranked messages')
-              )
-          )
           .toPromise()
       })
     )()


### PR DESCRIPTION
Closes #155 

- remove `initMsgs`
- add `sendMsg` which will forward the message the SU, cache it, then return a { crank }` that when called, will read the result of the message from the CU and crank it's messages