### PR TITLE
refactor(dev-cli): added ao lib to loader.lua #274

### DIFF
--- a/dev-cli/container/src/ao.lua
+++ b/dev-cli/container/src/ao.lua
@@ -1,0 +1,147 @@
+local ao = { _version = "0.0.3", id = "", _module = "", authorities = {}, outbox = { Messages = {}, Spawns = {}, _ref = 0 } }
+
+function isArray(table)
+  if type(table) == "table" then
+      local maxIndex = 0
+      for k, v in pairs(table) do
+          if type(k) ~= "number" or k < 1 or math.floor(k) ~= k then
+              return false -- If there's a non-integer key, it's not an array
+          end
+          maxIndex = math.max(maxIndex, k)
+      end
+      -- If the highest numeric index is equal to the number of elements, it's an array
+      return maxIndex == #table
+  end
+  return false
+end
+
+function ao.init(env) 
+  if ao.id == "" then
+    ao.id = env.Process.Id
+  end
+
+  if ao._module == "" then
+    for _, o in ipairs(env.Process.Tags) do
+      if o.name == "Module" then
+        ao._module = o.value
+      end
+    end
+  end
+  
+  if #ao.authorities < 1 then
+    for _, o in ipairs(env.Process.Tags) do
+      if o.name == "Authority" then
+        table.insert(ao.authorities, o.value)
+      end
+    end
+  end
+
+  ao.outbox = { Messages = {}, Spawns = {} }
+  ao.env = env
+  
+end
+
+-- clears outbox
+function ao.clearOutbox()
+  ao.outbox = { Messages = {}, Spawns = {} }
+end
+
+function ao.send(msg) 
+  assert(type(msg) == 'table', 'msg should be a table')
+  
+  local message = {
+    Target = msg.Target,
+    Data = msg.Data,
+    Tags = {
+      { name = "Data-Protocol", value = "ao" },
+      { name = "Variant", value = "ao.TN.1"},
+      { name = "Type", value = "Message" },
+      { name = "From-Process", value = ao.id },
+      { name = "From-Module", value = ao._module }
+    }
+  }
+  
+  if msg.Tags then
+    if isArray(msg.Tags) then
+      for _, o in ipairs(msg.Tags) do
+        table.insert(message.Tags, o)
+      end
+    else
+      for k,v in pairs(msg.Tags) do
+        table.insert(message.Tags, { name = k, value = v })
+      end  
+    end
+  end
+
+  -- add message to outbox
+  table.insert(ao.outbox.Messages, message)
+  
+  return message
+end
+
+function ao.spawn(module, msg)
+  assert(type(module) == "string", "module source id is required!") 
+  assert(type(msg) == 'table', 'msg should be a table')
+  -- inc spawn reference
+  ao._ref = ao._ref + 1
+
+  if not msg.Data then
+    data = "NODATA"
+  end
+
+  local spawn = {
+    Data = data,
+    Tags = {
+      { name = "Data-Protocol", value = "ao" },
+      { name = "Variant", value = "ao.TN.1"},
+      { name = "Type", value = "Process" },
+      { name = "From-Process", value = ao.id },
+      { name = "From-Module", value = ao._module },
+      { name = "Module", value = module },
+      { name = "Ref_", value = ao._ref }
+    }
+  }
+
+  if msg.Tags then
+    if isArray(msg.Tags) then
+      for _, o in ipairs(msg.Tags) do
+        table.insert(spawn.Tags, o)
+      end
+    else
+      for k,v in pairs(msg.Tags) do
+        table.insert(spawn.Tags, { name = k, value = v })
+      end  
+    end
+  end
+
+   -- add spawn to outbox
+   table.insert(ao.outbox.Spawns, spawn)
+
+  return spawn
+end
+
+function ao.isTrusted(msg) 
+  if #ao.authorities == 0 then
+    return true
+  end
+
+  for _, authority in ipairs(ao.authorities) do
+    if msg.From == authority then
+      return true
+    end
+    if msg.Owner == authority then
+      return true
+    end
+  end
+  return false
+end
+
+function ao.result(result)
+  return {
+    Output = result.Output or '',
+    Messages = ao.outbox.Messages,
+    Spawns = ao.outbox.Spawns
+  }
+end
+
+return ao

--- a/dev-cli/container/src/loader.lua
+++ b/dev-cli/container/src/loader.lua
@@ -1,11 +1,12 @@
 local json = require "json"
 local process = require ".process"
+ao = require "ao"
 
 function handle(msgJSON, aoJSON)
   -- decode inputs
   local msg = json.decode(msgJSON)
-  local ao = json.decode(aoJSON)
-
+  local env = json.decode(aoJSON)
+  ao.init(env)
   -- handle process
   --
   -- The process may throw an error, either intentionally or unintentionally

--- a/dev-cli/src/commands/init.js
+++ b/dev-cli/src/commands/init.js
@@ -5,14 +5,17 @@ import { Command } from '../deps.js'
 const LUA = `
 local process = { _version = "0.0.1" }
 
-function process.handle(msg, env) 
-  -- do stuff
-  local response = {
-    output = "Hello World",
-    messages = {},
-    spawns = {}
-  }
-  return response
+function process.handle(msg, ao) 
+  assert(ao.isTrusted(msg), 'ao Message is not trusted')
+  
+  if (msg.Data == "ping") then
+    ao.send({ Target = msg.From, Data = "pong" })
+  end
+  
+  return ao.result({
+    Output = 'sent pong reply'
+  })
+
 end
 
 return process


### PR DESCRIPTION
This PR, adds the `ao` messaging library to dev-cli, and updates the init template:

```lua
local process = { _version = "0.0.2" }

function process.handle(msg, ao) 
  assert(ao.isTrusted(msg), 'ao Message is not trusted')
  
  if (msg.Data == "ping") then
    ao.send({ Target = msg.From, Data = "pong" })
  end
  
  return ao.result({
    Output = 'sent pong reply'
  })

end

return process
```


