### PR TITLE
fix(scheduler-utils): only cache origin in Location header when following redirects #454

### DIFF
--- a/scheduler-utils/src/client/scheduler.js
+++ b/scheduler-utils/src/client/scheduler.js
@@ -3,7 +3,7 @@ export function checkForRedirectWith ({ fetch }) {
     const response = await fetch(`${url}?process-id=${process}`, { method: 'GET', redirect: 'manual' })
     // In an HTTP redirect the Location header is the new url
     if ([301, 302, 307, 308].includes(response.status)) {
-      return response.headers.get('Location')
+      return new URL(response.headers.get('Location')).origin
     }
     return url
   }

--- a/scheduler-utils/src/client/scheduler.test.js
+++ b/scheduler-utils/src/client/scheduler.test.js
@@ -8,7 +8,7 @@ const mockFetch = (url, options) => {
       status: 302,
       headers: {
         get: (header) => {
-          if (header === 'Location') return 'http://newlocation.com'
+          if (header === 'Location') return 'http://newlocation.com?process-id=123'
         }
       }
     })


### PR DESCRIPTION
Closes #454 