### PR TITLE
feat(cu): chain off earlier pending readState eval streams to prevent duplicate work

### DIFF
--- a/servers/cu/src/domain/api/readState.js
+++ b/servers/cu/src/domain/api/readState.js
@@ -1,6 +1,7 @@
 import { isNotNil, join } from 'ramda'
 import { Resolved, fromPromise, of } from 'hyper-async'
 
+import { findPendingForProcessBeforeWith } from '../utils.js'
 import { findEvaluationSchema } from '../dal.js'
 import { loadProcessWith } from '../lib/loadProcess.js'
 import { loadModuleWith } from '../lib/loadModule.js'
@@ -13,6 +14,8 @@ import { hydrateMessagesWith } from '../lib/hydrateMessages.js'
  *
  * If another request comes in to invoke a readState that is already
  * pending, then we will just return that Async instead of spinning up a new readState.
+ *
+ * @type {Map<string, { startTime: Date, pending: Promise<any> }}
  */
 export const pendingReadState = new Map()
 const pendingKey = join(',')
@@ -20,6 +23,7 @@ const removePending = (key) => (res) => {
   pendingReadState.delete(key)
   return res
 }
+const findPendingForProcessBefore = findPendingForProcessBeforeWith(pendingReadState)
 
 /**
  * @typedef State
@@ -72,100 +76,139 @@ export function readStateWith (env) {
 
     const key = pendingKey([processId, to, ordinate, cron, exact, needsMemory])
     if (!pendingReadState.has(key)) {
+      let newEntry
+      const pendingForProcessBefore = findPendingForProcessBefore({ processId, timestamp: to })
+      /**
+       * Determine whether we can chain off of a pending readState
+       * eval stream
+       */
+      if (pendingForProcessBefore) {
+        const [pendingKey, { pending, chainedTo }] = pendingForProcessBefore
+        env.logger(
+          'found pending readState at "%j" to chain to, for incoming readState "%s"',
+          { key: pendingKey, chainedTo },
+          key
+        )
+        newEntry = {
+          startTime: new Date(),
+          chainedTo: pendingKey,
+          /**
+           * chain off already pending readState, to start evaling
+           * where it left off from
+           *
+           * @type {Promise}
+           */
+          pending
+        }
+      } else {
+        newEntry = {
+          startTime: new Date(),
+          chainedTo: undefined,
+          /**
+           * Nothing to chain from, so just resolve
+           */
+          pending: Promise.resolve()
+        }
+      }
+
       pendingReadState.set(
         key,
         {
-          startTime: new Date(),
-          pending: of({ id: processId, messageId, to, ordinate, cron, stats, needsMemory })
-            .chain(loadProcess)
-            .chain((res) => {
-              /**
-               * The exact evaluation (identified by its input messages timestamp)
-               * was found in the cache, so just return it.
-               *
-               * evaluate sets output below, so since we've found the output
-               * without evaluating, we simply set output to the result of the cached
-               * evaluation.
-               *
-               * This exposes a single api for upstream to consume
-               */
-              if (res.exact) return Resolved({ ...res, output: res.result })
+          startTime: newEntry.startTime,
+          chainedTo: newEntry.chainedTo, // string (key) or undefined if not chained
+          /**
+           * chain off newEntry.start, then continue eval
+           */
+          pending: newEntry.pending.then(() =>
+            of({ id: processId, messageId, to, ordinate, cron, stats, needsMemory })
+              .chain(loadProcess)
+              .chain((res) => {
+                /**
+                 * The exact evaluation (identified by its input messages timestamp)
+                 * was found in the cache, so just return it.
+                 *
+                 * evaluate sets output below, so since we've found the output
+                 * without evaluating, we simply set output to the result of the cached
+                 * evaluation.
+                 *
+                 * This exposes a single api for upstream to consume
+                 */
+                if (res.exact) return Resolved({ ...res, output: res.result })
 
-              return of(res)
-                .chain(loadModule)
-                .chain(loadMessages)
-                .chain(hydrateMessages)
+                return of(res)
+                  .chain(loadModule)
+                  .chain(loadMessages)
+                  .chain(hydrateMessages)
                 // { output }
-                .chain(evaluate)
-                .chain((ctx) => {
-                  /**
-                   * Some upstream apis like readResult need an exact match on the message evaluation,
-                   * and pass the 'exact' flag
-                   *
-                   * If this flag is set, we ensure that by fetching the exact match from the db.
-                   * This hedges against race conditions where multiple requests are resulting in the evaluation
-                   * of the same messages in a process.
-                   *
-                   * Having this should allow readState to always start on the latestEvalutaion, relative to 'to',
-                   * and reduce the chances of unnecessary 409s, due to concurrent evalutions of the same messages,
-                   * across multiple requests.
-                   */
-                  if (exact) {
-                    return findEvaluation({ processId, to, ordinate, cron })
-                      /**
-                       * Mirror output shape from loadProcess, using the exact evaluation
-                       * as the "starting point"
-                       *
-                       * Also set result.Memory to the output Memory, since we will have evaluated
-                       * up to that exact message, so the output Memory is what we need
-                       */
-                      .map((evaluation) => ({
-                        ...ctx,
-                        result: {
-                          ...evaluation.output,
-                          Memory: ctx.output.Memory
-                        },
-                        output: evaluation.output,
-                        from: evaluation.timestamp,
-                        fromBlockHeight: evaluation.blockHeight,
-                        ordinate: evaluation.ordinate
-                      }))
-                  }
-
-                  /**
-                   * Mirror the output shape from loadProcess, using the last message
-                   * evaled, and fallback to ctx (in the case that no new messages were found to evaluate)
-                   *
-                   * Also set result.Memory to the last memory evaluated
-                   */
-                  return Resolved(({
-                    ...ctx,
-                    result: ctx.output,
-                    from: ctx.last.timestamp,
-                    fromBlockHeight: ctx.last.blockHeight,
-                    ordinate: ctx.last.ordinate
-                  }))
-                })
-            })
-            .bimap(logStats, logStats)
-            /**
-             * Always remove the pending work, when it's complete
-             */
-            .bimap(removePending(key), removePending(key))
-            /**
-             * TODO: Need to figure out how to push this to the edge.
-             *
-             * Unwrapping here to prevent duplicate work,
-             * as a result of the same Async being forked twice.
-             * It is still wrapped in an Async below, but it's the same
-             * underlying Promise, so no duplicate work
-             *
-             * Need to figure out how to push this to the edge.
-             *
-             * The only other place toPromise is used is on clients, routes (edges),
-             * and evaluate (to prevent callstack overflow)
-             */
-            .toPromise()
+                  .chain(evaluate)
+                  .chain((ctx) => {
+                    /**
+                     * Some upstream apis like readResult need an exact match on the message evaluation,
+                     * and pass the 'exact' flag
+                     *
+                     * If this flag is set, we ensure that by fetching the exact match from the db.
+                     * This hedges against race conditions where multiple requests are resulting in the evaluation
+                     * of the same messages in a process.
+                     *
+                     * Having this should allow readState to always start on the latestEvalutaion, relative to 'to',
+                     * and reduce the chances of unnecessary 409s, due to concurrent evalutions of the same messages,
+                     * across multiple requests.
+                     */
+                    if (exact) {
+                      return findEvaluation({ processId, to, ordinate, cron })
+                        /**
+                         * Mirror output shape from loadProcess, using the exact evaluation
+                         * as the "starting point"
+                         *
+                         * Also set result.Memory to the output Memory, since we will have evaluated
+                         * up to that exact message, so the output Memory is what we need
+                         */
+                        .map((evaluation) => ({
+                          ...ctx,
+                          result: {
+                            ...evaluation.output,
+                            Memory: ctx.output.Memory
+                          },
+                          output: evaluation.output,
+                          from: evaluation.timestamp,
+                          fromBlockHeight: evaluation.blockHeight,
+                          ordinate: evaluation.ordinate
+                        }))
+                    }
+                    /**
+                     * Mirror the output shape from loadProcess, using the last message
+                     * evaled, and fallback to ctx (in the case that no new messages were found to evaluate)
+                     *
+                     * Also set result.Memory to the last memory evaluated
+                     */
+                    return Resolved(({
+                      ...ctx,
+                      result: ctx.output,
+                      from: ctx.last.timestamp,
+                      fromBlockHeight: ctx.last.blockHeight,
+                      ordinate: ctx.last.ordinate
+                    }))
+                  })
+              })
+              .bimap(logStats, logStats)
+              /**
+               * Always remove the pending work, when it's complete
+               */
+              .bimap(removePending(key), removePending(key))
+              /**
+               * TODO: Need to figure out how to push this to the edge.
+               *
+               * Unwrapping here to prevent duplicate work,
+               * as a result of the same Async being forked twice.
+               * It is still wrapped in an Async below, but it's the same
+               * underlying Promise, so no duplicate work
+               *
+               * Need to figure out how to push this to the edge.
+               *
+               * The only other place toPromise is used is on clients, routes (edges),
+               * and evaluate (to prevent callstack overflow)
+               */
+              .toPromise())
         }
       )
     }


### PR DESCRIPTION
The CU already re-uses pending readState evaluation streams if the requests are requesting to evaluate a process up to the same message.

This adds a further optimization, that will "chain" readState operations, which should help with cascading readState evals.

For example:

If an evaluation stream for process X up to message 10 is currently running, then a new requests for process X up to message 11 arrives, it will simply chain off of the work being performed by the pending evaluation stream:

```
processAMessage10---->working--->DONE--|
    later----processAMessage11---------|-->eval diff (1 msg)--> DONE--|
      later------processAMessage12------------------------------------|-->eval diff (1 msg)--> DONE
```

Without this, because each eval stream doesn't cache the memory until the end of the eval stream, `processAMessage11` will cold start, followed by `processAMessage12` cold starting, all 3 eval streams performing duplicate work, which is really just sequential work.

TL;DR: dedupe evaluation work being performed for any one process