### PR TITLE
feat(cu): use process cache more proactively to locate scheduler, hedging against gateway finality issues

### DIFF
--- a/servers/cu/src/domain/client/ao-su.js
+++ b/servers/cu/src/domain/client/ao-su.js
@@ -48,9 +48,10 @@ export const loadMessagesWith = ({ fetch, logger: _logger, pageSize }) => {
         await Promise.resolve()
           .then(() => {
             logger(
-              'Loading next page of maximum %s messages for process %s from %s to %s',
+              'Loading next page of max %s messages for process "%s" from SU "%s" between "%s" and "%s"',
               pageSize,
               processId,
+              suUrl,
               from || 'initial',
               to || 'latest'
             )
@@ -70,9 +71,10 @@ export const loadMessagesWith = ({ fetch, logger: _logger, pageSize }) => {
       }
 
       logger(
-        'Successfully loaded %s scheduled messages for process "%s" from "%s" to "%s"...',
+        'Successfully loaded %s scheduled messages for process "%s" from SU "%s" between "%s" and "%s"...',
         total,
         processId,
+        suUrl,
         from || 'initial',
         to || 'latest')
     }

--- a/servers/cu/src/domain/dal.js
+++ b/servers/cu/src/domain/dal.js
@@ -191,3 +191,11 @@ export const locateProcessSchema = z.function()
       url: z.string()
     })
   ))
+
+export const locateSchedulerSchema = z.function()
+  .args(z.string())
+  .returns(z.promise(
+    z.object({
+      url: z.string()
+    })
+  ))

--- a/servers/cu/src/domain/dal.js
+++ b/servers/cu/src/domain/dal.js
@@ -184,7 +184,7 @@ export const loadMessageMetaSchema = z.function()
     })
   ))
 
-export const locateSchedulerSchema = z.function()
+export const locateProcessSchema = z.function()
   .args(z.string())
   .returns(z.promise(
     z.object({

--- a/servers/cu/src/domain/index.js
+++ b/servers/cu/src/domain/index.js
@@ -183,7 +183,7 @@ export const createApis = async (ctx) => {
     loadTimestamp: AoSuClient.loadTimestampWith({ fetch: ctx.fetch, logger }),
     loadProcess: AoSuClient.loadProcessWith({ fetch: ctx.fetch, logger }),
     loadMessages: AoSuClient.loadMessagesWith({ fetch: ctx.fetch, pageSize: 1000, logger }),
-    locateScheduler: locateDataloader.load.bind(locateDataloader),
+    locateProcess: locateDataloader.load.bind(locateDataloader),
     doesExceedModuleMaxMemory: WasmClient.doesExceedModuleMaxMemoryWith({ PROCESS_WASM_MEMORY_MAX_LIMIT: ctx.PROCESS_WASM_MEMORY_MAX_LIMIT }),
     doesExceedModuleMaxCompute: WasmClient.doesExceedModuleMaxComputeWith({ PROCESS_WASM_COMPUTE_MAX_LIMIT: ctx.PROCESS_WASM_COMPUTE_MAX_LIMIT }),
     logger

--- a/servers/cu/src/domain/lib/loadMessageMeta.js
+++ b/servers/cu/src/domain/lib/loadMessageMeta.js
@@ -1,7 +1,7 @@
 import { fromPromise } from 'hyper-async'
 import { z } from 'zod'
 
-import { loadMessageMetaSchema, locateSchedulerSchema } from '../dal.js'
+import { loadMessageMetaSchema, locateProcessSchema } from '../dal.js'
 import { trimSlash } from '../utils.js'
 
 /**
@@ -48,10 +48,10 @@ export function loadMessageMetaWith (env) {
   env = { ...env, logger }
 
   const loadMessageMeta = fromPromise(loadMessageMetaSchema.implement(env.loadMessageMeta))
-  const locateScheduler = fromPromise(locateSchedulerSchema.implement(env.locateScheduler))
+  const locateProcess = fromPromise(locateProcessSchema.implement(env.locateProcess))
 
   return (ctx) => {
-    return locateScheduler(ctx.processId)
+    return locateProcess(ctx.processId)
       .chain(({ url }) => loadMessageMeta({
         suUrl: trimSlash(url),
         processId: ctx.processId,

--- a/servers/cu/src/domain/lib/loadMessageMeta.test.js
+++ b/servers/cu/src/domain/lib/loadMessageMeta.test.js
@@ -10,7 +10,7 @@ const logger = createLogger('ao-cu:readState')
 describe('loadMessageMeta', () => {
   test('should append processId and timestamp to ctx', async () => {
     const loadMessageMeta = loadMessageMetaWith({
-      locateScheduler: async (id) => {
+      locateProcess: async (id) => {
         assert.equal(id, 'process-123')
         return { url: 'https://foo.bar' }
       },

--- a/servers/cu/src/domain/lib/loadMessageMeta.test.js
+++ b/servers/cu/src/domain/lib/loadMessageMeta.test.js
@@ -10,6 +10,8 @@ const logger = createLogger('ao-cu:readState')
 describe('loadMessageMeta', () => {
   test('should append processId and timestamp to ctx', async () => {
     const loadMessageMeta = loadMessageMetaWith({
+      findProcess: async () => { throw new Error('woops') },
+      locateScheduler: async () => assert.fail('should not call if process is not cached'),
       locateProcess: async (id) => {
         assert.equal(id, 'process-123')
         return { url: 'https://foo.bar' }
@@ -29,5 +31,77 @@ describe('loadMessageMeta', () => {
       .toPromise()
 
     assert.deepStrictEqual(res, { processId: 'process-123', timestamp: 1697574792000, nonce: 1 })
+  })
+
+  test('should use the cached process', async () => {
+    const loadMessageMeta = loadMessageMetaWith({
+      findProcess: async () => ({
+        id: 'process-123',
+        owner: 'woohoo',
+        signature: 'sig-123',
+        anchor: null,
+        data: 'data-123',
+        tags: [
+          { name: 'Scheduler', value: 'scheduler-123' },
+          { name: 'Foo', value: 'Bar' }
+        ],
+        block: { height: 123, timestamp: 1697574792 }
+      }),
+      locateScheduler: async (owner) => {
+        assert.equal(owner, 'scheduler-123')
+        return { url: 'https://from.cache' }
+      },
+      locateProcess: async (id) => assert.fail('should not call if found in cache'),
+      loadMessageMeta: async (args) => {
+        assert.deepStrictEqual(args, {
+          suUrl: 'https://from.cache',
+          processId: 'process-123',
+          messageTxId: 'message-tx-123'
+        })
+        return { processId: 'process-123', timestamp: 1697574792000, nonce: 1 }
+      },
+      logger
+    })
+
+    await loadMessageMeta({ processId: 'process-123', messageTxId: 'message-tx-123' })
+      .toPromise()
+  })
+
+  test('should fallback to locateProcess is locateScheduler fails', async () => {
+    const loadMessageMeta = loadMessageMetaWith({
+      findProcess: async () => ({
+        id: 'process-123',
+        owner: 'woohoo',
+        signature: 'sig-123',
+        anchor: null,
+        data: 'data-123',
+        tags: [
+          { name: 'Scheduler', value: 'scheduler-123' },
+          { name: 'Foo', value: 'Bar' }
+        ],
+        block: { height: 123, timestamp: 1697574792 }
+      }),
+      locateScheduler: async (owner) => {
+        assert.equal(owner, 'scheduler-123')
+        // Simulate error from gateway
+        throw new Error('woops')
+      },
+      locateProcess: async (id) => {
+        assert.equal(id, 'process-123')
+        return { url: 'https://foo.bar' }
+      },
+      loadMessageMeta: async (args) => {
+        assert.deepStrictEqual(args, {
+          suUrl: 'https://foo.bar',
+          processId: 'process-123',
+          messageTxId: 'message-tx-123'
+        })
+        return { processId: 'process-123', timestamp: 1697574792000, nonce: 1 }
+      },
+      logger
+    })
+
+    await loadMessageMeta({ processId: 'process-123', messageTxId: 'message-tx-123' })
+      .toPromise()
   })
 })

--- a/servers/cu/src/domain/lib/loadProcess.js
+++ b/servers/cu/src/domain/lib/loadProcess.js
@@ -2,9 +2,9 @@ import { Rejected, Resolved, fromPromise, of } from 'hyper-async'
 import { always, identity, isNotNil, mergeRight, pick } from 'ramda'
 import { z } from 'zod'
 
-import { findEvaluationSchema, findProcessSchema, loadProcessSchema, locateProcessSchema, saveProcessSchema } from '../dal.js'
+import { findEvaluationSchema, findProcessSchema, loadProcessSchema, locateProcessSchema, locateSchedulerSchema, saveProcessSchema } from '../dal.js'
 import { blockSchema, rawTagSchema } from '../model.js'
-import { eqOrIncludes, parseTags, trimSlash } from '../utils.js'
+import { eqOrIncludes, findRawTag, parseTags, trimSlash } from '../utils.js'
 
 /**
  * The result that is produced from this step
@@ -14,6 +14,10 @@ import { eqOrIncludes, parseTags, trimSlash } from '../utils.js'
  * is always added to context
  */
 const ctxSchema = z.object({
+  /**
+   * The url of the SU where the process is located
+   */
+  suUrl: z.string().min(1),
   /**
    * the signature of the process
    *
@@ -82,8 +86,9 @@ const ctxSchema = z.object({
   exact: z.boolean().default(false)
 }).passthrough()
 
-function getProcessMetaWith ({ loadProcess, locateProcess, findProcess, saveProcess, logger }) {
+function getProcessMetaWith ({ loadProcess, locateProcess, locateScheduler, findProcess, saveProcess, logger }) {
   locateProcess = fromPromise(locateProcessSchema.implement(locateProcess))
+  locateScheduler = fromPromise(locateSchedulerSchema.implement(locateScheduler))
   findProcess = fromPromise(findProcessSchema.implement(findProcess))
   saveProcess = fromPromise(saveProcessSchema.implement(saveProcess))
   loadProcess = fromPromise(loadProcessSchema.implement(loadProcess))
@@ -92,46 +97,8 @@ function getProcessMetaWith ({ loadProcess, locateProcess, findProcess, saveProc
     ? Resolved(tags)
     : Rejected(`Tag '${name}': ${err}`)
 
-  /**
-   * Load the process from the SU, extracting the metadata,
-   * and then saving to the db
-   */
-  function loadFromSu (processId) {
-    return locateProcess(processId)
-      .chain(({ url }) => loadProcess({ suUrl: trimSlash(url), processId }))
-      /**
-       * Verify the process by examining the tags
-       */
-      .chain((ctx) =>
-        of(ctx.tags)
-          .map(parseTags)
-          .chain(checkTag('Data-Protocol', eqOrIncludes('ao'), 'value \'ao\' was not found on process'))
-          .chain(checkTag('Type', eqOrIncludes('Process'), 'value \'Process\' was not found on process'))
-          .chain(checkTag('Module', isNotNil, 'was not found on process'))
-          .map(always({ id: processId, ...ctx }))
-          .bimap(
-            logger.tap('Verifying process failed: %s'),
-            logger.tap('Verified process. Saving to db...')
-          )
-      )
-      /**
-       * Attempt to save to the db
-       */
-      .chain((process) =>
-        saveProcess(process)
-          .bimap(
-            logger.tap('Could not save process to db. Nooping'),
-            logger.tap('Saved process')
-          )
-          .bichain(
-            always(Resolved(process)),
-            always(Resolved(process))
-          )
-      )
-  }
-
-  return (processId) =>
-    findProcess({ processId })
+  function maybeCached (processId) {
+    return findProcess({ processId })
       /**
        * The process could indeed not be found, or there was some other error
        * fetching from persistence. Regardless, we will fallback to loading from
@@ -141,11 +108,67 @@ function getProcessMetaWith ({ loadProcess, locateProcess, findProcess, saveProc
         logger.tap('Could not find process in db. Loading from chain...'),
         logger.tap('found process in db %j')
       )
+      /**
+       * Locate the scheduler for the process and attach to context
+       */
+      .chain((process) =>
+        of(process.tags)
+          .map((tags) => findRawTag('Scheduler', tags))
+          .chain((tag) => tag ? Resolved(tag.value) : Rejected('No Cached Process'))
+          .chain(locateScheduler)
+          .map(({ url: suUrl }) => [process, trimSlash(suUrl)])
+      )
+  }
+
+  /**
+   * Load the process from the SU, extracting the metadata,
+   * and then saving to the db
+   */
+  function loadFromSu (processId) {
+    return locateProcess(processId)
+      .chain(({ url }) =>
+        loadProcess({ suUrl: trimSlash(url), processId })
+          /**
+           * Verify the process by examining the tags
+           */
+          .chain((ctx) =>
+            of(ctx.tags)
+              .map(parseTags)
+              .chain(checkTag('Data-Protocol', eqOrIncludes('ao'), 'value \'ao\' was not found on process'))
+              .chain(checkTag('Type', eqOrIncludes('Process'), 'value \'Process\' was not found on process'))
+              .chain(checkTag('Module', isNotNil, 'was not found on process'))
+              .map(always({ id: processId, ...ctx }))
+              .bimap(
+                logger.tap('Verifying process failed: %s'),
+                logger.tap('Verified process. Saving to db...')
+              )
+          )
+          /**
+           * Attempt to save to the db
+           */
+          .chain((process) =>
+            saveProcess(process)
+              .bimap(
+                logger.tap('Could not save process to db. Nooping'),
+                logger.tap('Saved process')
+              )
+              .bichain(
+                always(Resolved(process)),
+                always(Resolved(process))
+              )
+          )
+          .map((process) => [process, trimSlash(url)])
+      )
+  }
+
+  return (processId) =>
+    maybeCached(processId)
       .bichain(
         () => loadFromSu(processId),
         Resolved
       )
-      .map(process => ({
+      .map(([process, suUrl]) => ({
+        suUrl,
         signature: process.signature,
         data: process.data,
         anchor: process.anchor,

--- a/servers/cu/src/domain/lib/loadProcess.js
+++ b/servers/cu/src/domain/lib/loadProcess.js
@@ -2,7 +2,7 @@ import { Rejected, Resolved, fromPromise, of } from 'hyper-async'
 import { always, identity, isNotNil, mergeRight, pick } from 'ramda'
 import { z } from 'zod'
 
-import { findEvaluationSchema, findProcessSchema, loadProcessSchema, locateSchedulerSchema, saveProcessSchema } from '../dal.js'
+import { findEvaluationSchema, findProcessSchema, loadProcessSchema, locateProcessSchema, saveProcessSchema } from '../dal.js'
 import { blockSchema, rawTagSchema } from '../model.js'
 import { eqOrIncludes, parseTags, trimSlash } from '../utils.js'
 
@@ -82,8 +82,8 @@ const ctxSchema = z.object({
   exact: z.boolean().default(false)
 }).passthrough()
 
-function getProcessMetaWith ({ loadProcess, locateScheduler, findProcess, saveProcess, logger }) {
-  locateScheduler = fromPromise(locateSchedulerSchema.implement(locateScheduler))
+function getProcessMetaWith ({ loadProcess, locateProcess, findProcess, saveProcess, logger }) {
+  locateProcess = fromPromise(locateProcessSchema.implement(locateProcess))
   findProcess = fromPromise(findProcessSchema.implement(findProcess))
   saveProcess = fromPromise(saveProcessSchema.implement(saveProcess))
   loadProcess = fromPromise(loadProcessSchema.implement(loadProcess))
@@ -97,7 +97,7 @@ function getProcessMetaWith ({ loadProcess, locateScheduler, findProcess, savePr
    * and then saving to the db
    */
   function loadFromSu (processId) {
-    return locateScheduler(processId)
+    return locateProcess(processId)
       .chain(({ url }) => loadProcess({ suUrl: trimSlash(url), processId }))
       /**
        * Verify the process by examining the tags

--- a/servers/cu/src/domain/lib/loadProcess.test.js
+++ b/servers/cu/src/domain/lib/loadProcess.test.js
@@ -29,7 +29,7 @@ describe('loadProcess', () => {
         cron: undefined,
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
-      locateScheduler: async (id) => {
+      locateProcess: async (id) => {
         assert.equal(id, PROCESS)
         return { url: 'https://foo.bar' }
       },
@@ -91,7 +91,7 @@ describe('loadProcess', () => {
         cron: undefined,
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
-      locateScheduler: async (_id) => assert.fail('should not locate su if found in db'),
+      locateProcess: async (_id) => assert.fail('should not locate su if found in db'),
       loadProcess: async (_id) => assert.fail('should not load process block if found in db'),
       logger
     })
@@ -142,7 +142,7 @@ describe('loadProcess', () => {
       findLatestEvaluation: async ({ processId, timestamp }) => {
         assert.fail('should not be called when exact match is found')
       },
-      locateScheduler: async (id) => ({ url: 'https://foo.bar' }),
+      locateProcess: async (id) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags,
@@ -186,7 +186,7 @@ describe('loadProcess', () => {
         cron: undefined,
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
-      locateScheduler: async (id) => ({ url: 'https://foo.bar' }),
+      locateProcess: async (id) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags,
@@ -216,7 +216,7 @@ describe('loadProcess', () => {
         cron: undefined,
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
-      locateScheduler: async (id) => ({ url: 'https://foo.bar' }),
+      locateProcess: async (id) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags,
@@ -244,7 +244,7 @@ describe('loadProcess', () => {
         cron: undefined,
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
-      locateScheduler: async (id) => ({ url: 'https://foo.bar' }),
+      locateProcess: async (id) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags: [
@@ -274,7 +274,7 @@ describe('loadProcess', () => {
         cron: undefined,
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
-      locateScheduler: async (id) => ({ url: 'https://foo.bar' }),
+      locateProcess: async (id) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags: [
@@ -304,7 +304,7 @@ describe('loadProcess', () => {
         cron: undefined,
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
-      locateScheduler: async (id) => ({ url: 'https://foo.bar' }),
+      locateProcess: async (id) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags: [

--- a/servers/cu/src/domain/lib/loadProcess.test.js
+++ b/servers/cu/src/domain/lib/loadProcess.test.js
@@ -10,7 +10,7 @@ const PROCESS = 'process-123-9HdeqeuYQOgMgWucro'
 const logger = createLogger('ao-cu:readState')
 
 describe('loadProcess', () => {
-  test('appends process owner, tags, block, buffer as process tags parsed as JSON, result, from, fromCron, fromBlockHeight and evaluatedAt to ctx', async () => {
+  test('appends suUrl, process owner, tags, block, buffer as process tags parsed as JSON, result, from, fromCron, fromBlockHeight and evaluatedAt to ctx', async () => {
     const tags = [
       { name: 'Module', value: 'foobar' },
       { name: 'Data-Protocol', value: 'ao' },
@@ -33,6 +33,7 @@ describe('loadProcess', () => {
         assert.equal(id, PROCESS)
         return { url: 'https://foo.bar' }
       },
+      locateScheduler: async () => assert.fail('should not locate su if not found in db'),
       loadProcess: async ({ suUrl, processId }) => {
         assert.equal(processId, PROCESS)
         assert.equal(suUrl, 'https://foo.bar')
@@ -50,6 +51,7 @@ describe('loadProcess', () => {
 
     const res = await loadProcess({ id: PROCESS, to: '1697574792000' }).toPromise()
 
+    assert.deepStrictEqual(res.suUrl, 'https://foo.bar')
     assert.deepStrictEqual(res.tags, tags)
     assert.deepStrictEqual(res.owner, 'woohoo')
     assert.deepStrictEqual(res.signature, 'sig-123')
@@ -65,12 +67,13 @@ describe('loadProcess', () => {
     assert.equal(res.id, PROCESS)
   })
 
-  test('use process from db to set owner, tags, and block', async () => {
+  test('use process from db to set suUrl, owner, tags, and block', async () => {
     const tags = [
       { name: 'Module', value: 'foobar' },
       { name: 'Data-Protocol', value: 'ao' },
       { name: 'Type', value: 'Process' },
-      { name: 'Foo', value: 'Bar' }
+      { name: 'Foo', value: 'Bar' },
+      { name: 'Scheduler', value: 'scheduler-123' }
     ]
     const loadProcess = loadProcessWith({
       findProcess: async () => ({
@@ -91,12 +94,17 @@ describe('loadProcess', () => {
         cron: undefined,
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
-      locateProcess: async (_id) => assert.fail('should not locate su if found in db'),
+      locateScheduler: async (owner) => {
+        assert.equal(owner, 'scheduler-123')
+        return { url: 'https://from.cache' }
+      },
+      locateProcess: async (_id) => assert.fail('should not locate process if found in db'),
       loadProcess: async (_id) => assert.fail('should not load process block if found in db'),
       logger
     })
 
     const res = await loadProcess({ id: PROCESS }).toPromise()
+    assert.deepStrictEqual(res.suUrl, 'https://from.cache')
     assert.deepStrictEqual(res.tags, tags)
     assert.deepStrictEqual(res.owner, 'woohoo')
     assert.deepStrictEqual(res.signature, 'sig-123')
@@ -143,6 +151,7 @@ describe('loadProcess', () => {
         assert.fail('should not be called when exact match is found')
       },
       locateProcess: async (id) => ({ url: 'https://foo.bar' }),
+      locateScheduler: async () => assert.fail('should not locate su if not found in db'),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags,
@@ -187,6 +196,7 @@ describe('loadProcess', () => {
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
       locateProcess: async (id) => ({ url: 'https://foo.bar' }),
+      locateScheduler: async () => assert.fail('should not locate su if not found in db'),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags,
@@ -217,6 +227,7 @@ describe('loadProcess', () => {
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
       locateProcess: async (id) => ({ url: 'https://foo.bar' }),
+      locateScheduler: async () => assert.fail('should not locate su if not found in db'),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags,
@@ -245,6 +256,7 @@ describe('loadProcess', () => {
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
       locateProcess: async (id) => ({ url: 'https://foo.bar' }),
+      locateScheduler: async () => assert.fail('should not locate su if not found in db'),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags: [
@@ -275,6 +287,7 @@ describe('loadProcess', () => {
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
       locateProcess: async (id) => ({ url: 'https://foo.bar' }),
+      locateScheduler: async () => assert.fail('should not locate su if not found in db'),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags: [
@@ -305,6 +318,7 @@ describe('loadProcess', () => {
         ordinate: COLLATION_SEQUENCE_MIN_CHAR
       }),
       locateProcess: async (id) => ({ url: 'https://foo.bar' }),
+      locateScheduler: async () => assert.fail('should not locate su if not found in db'),
       loadProcess: async (id) => ({
         owner: 'woohoo',
         tags: [


### PR DESCRIPTION
This PR makes it so the CU does not depend as much on the gateway for locating a process on a scheduler unit. Instead, the CU will leverage it's cache to obtain the `Scheduler` tag for the process and then only load the `Scheduler-Location` record from gateway (if not already cached.

This hedges against finality or backup issues with the gateway, especially for new processes, since we've observed that the gateway will sometimes not return a bona-fide ao process because of two reasons:

- finality
- optimistic cache expires before unbundling and indexing can be performed

TL;DR: this greatly reduces the dependency of the CU on the gateway, more proactively utilizing it's many caching layers.