### PR TITLE
feat(ur): add `redirect` strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 wallet.json
 dist
 .VSCodeCounter

--- a/servers/ur/.env.example
+++ b/servers/ur/.env.example
@@ -2,3 +2,4 @@ NODE_CONFIG_ENV="development"
 DEBUG=*
 HOSTS="https://foo.bar,https://fizz.buzz"
 AO_UNIT=cu
+STRATEGY=proxy

--- a/servers/ur/README.md
+++ b/servers/ur/README.md
@@ -11,8 +11,6 @@ This service will deterministically route `ao` Process operations to an underlyi
 - [Tests](#tests)
 - [Debug Logging](#debug-logging)
 - [Project Structure](#project-structure)
-  - [Entrypoint](#entrypoint)
-  - [Routing](#routing)
 - [System Requirements](#system-requirements)
 
 <!-- tocstop -->
@@ -32,6 +30,7 @@ There are a few environment variables that you MUST set:
 - `NODE_CONFIG_ENV`: whether the service should be ran in `development` or `production` mode. Basically, this loads a separate set of default configuration.
 - `AO_UNIT`: which `ao` Unit, either `cu` or `mu`, this Reverse Proxy Service is meant to mirror.
 - `HOSTS`: a comma-delimited string containing all of the underlying hosts that can Reverse Proxied to. If `AO_UNIT` is `cu`, then `HOSTS` should be a series of `ao` Compute Unit Hosts. Similarly if `AO_UNIT` is `mu` then `HOSTS` should be a series of `ao` Messenger Unit Hosts
+- `STRATEGY`: either `redirect` or `proxy` (default). If `STRATEGY` is `redirect`, the service will reply with an [HTTP 307 Temporary Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) to the underlying `ao` unit. If `STRATEGY` is `proxy`, the service will act as a reverse proxy to the underlying `ao` unit and forward the HTTP request itself.
 
 > In order for the Router's Reverse Proxying to be consistent, the ordering of the `HOST` list MUST be consistent.
 
@@ -49,18 +48,6 @@ All logging is scoped under the name `ao-router*`.
 ## Project Structure
 
 This `ao` Unit Router project is simple service, with minimal business logic.
-
-The total service boilerplate is less than ~200 lines while the business logic is less than ~10 lines.
-
-The ONLY custom code that's specific to the `ao` Units exists in the [entrypoint](./src/app.js), where the specific endpoints to Reverse Proxy are specified.
-
-### Entrypoint
-
-The entrypoint is `src/app.js` where the ONLY custom configuration is specified. Here, we mirror the `ao` Unit API for both the CU and MU, and set up the Reverse Proxying handlers.
-
-### Routing
-
-All routing logic can be found in `src/router.js`
 
 ## System Requirements
 

--- a/servers/ur/src/app.js
+++ b/servers/ur/src/app.js
@@ -1,84 +1,43 @@
-import { Readable } from 'node:stream'
+import { join } from 'node:path'
+
+import cors from 'cors'
 import express from 'express'
-import WarpArBundles from 'warp-arbundles'
+import heapdump from 'heapdump'
+import { pipe } from 'ramda'
 
-import { router } from './router.js'
+import { config } from './config.js'
+import { logger } from './logger.js'
 
-const { DataItem } = WarpArBundles
+import { proxyWith } from './proxy.js'
+import { redirectWith } from './redirect.js'
 
-/**
- * The ONLY custom bits needed for the router.
- *
- * Mount any custom endpoints, optionally reverse-proxying to the set of
- * underyling hosts with automatic failover, by using the injected revProxy handler
- */
-
-/**
- * The Reverse Proxy Configuration for an ao Compute Unit Router
- */
-function aoComputeUnitMount ({ app, revProxy }) {
-  app.get('/', revProxy({ processIdFromRequest: (req) => 'process' }))
-  app.get('/result/:messageTxId', revProxy({ processIdFromRequest: (req) => req.query['process-id'] }))
-  app.get('/results/:processId', revProxy({ processIdFromRequest: (req) => req.params.processId }))
-  app.get('/state/:processId', revProxy({ processIdFromRequest: (req) => req.params.processId }))
-  app.get('/cron/:processId', revProxy({ processIdFromRequest: (req) => req.params.processId }))
-  app.post('/dry-run', revProxy({ processIdFromRequest: (req) => req.query['process-id'] }))
+const middlewareWithByStrategy = {
+  proxy: proxyWith,
+  redirect: redirectWith
 }
 
-/**
- * The Reverse Proxy Configuration for an ao Messenger Unit Router
- */
-function aoMessengerUnitMount ({ app, revProxy }) {
-  class InvalidDataItemError extends Error {
-    constructor (...args) {
-      super(...args)
-      this.status = 422
-    }
+const middlewareWith = middlewareWithByStrategy[config.strategy]
+
+pipe(
+  (app) => app.use(cors()),
+  (app) => app.use(express.static(config.DUMP_PATH)),
+  middlewareWith({ ...config }),
+  (app) => {
+    const server = app.listen(config.port, () => {
+      logger(`Server is running on http://localhost:${config.port}`)
+    })
+
+    process.on('SIGTERM', () => {
+      logger('Recevied SIGTERM. Gracefully shutting down server...')
+      server.close(() => logger('Server Shut Down'))
+    })
+
+    process.on('SIGUSR2', () => {
+      const name = `${Date.now()}.heapsnapshot`
+      heapdump.writeSnapshot(join(config.DUMP_PATH, name))
+      console.log(name)
+    })
+
+    return server
   }
-
-  const isTagEqualTo = ({ name, value }) => (tag) => tag.name === name && tag.value === value
-  const isMessage = (dataItem) => !!dataItem.tags.find(isTagEqualTo({ name: 'Type', value: 'Message' }))
-  const isProcess = (dataItem) => !!dataItem.tags.find(isTagEqualTo({ name: 'Type', value: 'Process' }))
-
-  app.get('/', (req, res, next) => {
-    if (req.query.debug) return res.status(501).send('MU Tracing not implemented on the Router')
-
-    /**
-     * Continue the request, rev proxying with a static value in order to get the roout info response from a MU
-     */
-    return revProxy({ processIdFromRequest: () => 'process' })(req, res, next)
-  })
-
-  /**
-   * Since the MU receives opaque data items, we have to unpack it, to know which MU
-   * to route to
-   */
-  app.post('/', express.raw({ type: 'application/octet-stream', limit: '10mb' }), revProxy({
-    processIdFromRequest: async (req) => {
-      const dataItem = new DataItem(Buffer.from(req.body))
-
-      if (!(await dataItem.isValid())) throw new InvalidDataItemError('A valid and signed data item must be provided as the body')
-      /**
-       * The processId is the target on a message data item
-       */
-      if (isMessage(dataItem)) return dataItem.target
-      /**
-       * The processId is the dataItem itseld on a process data item
-       */
-      if (isProcess(dataItem)) return dataItem.id
-
-      throw new InvalidDataItemError('Could not determine ao type of DataItem based on tag \'Type\'')
-    },
-    /**
-     * Since we consumed the request stream in order to parse the data item and
-     * determine the processId, we must provide a new request stream, to be sent
-     * as the body on proxied request
-     */
-    restreamBody: (req) => Readable.from(req.body)
-  }))
-
-  app.post('/monitor/:processId', revProxy({ processIdFromRequest: (req) => req.params.processId }))
-  app.delete('/monitor/:processId', revProxy({ processIdFromRequest: (req) => req.params.processId }))
-}
-
-router({ cu: aoComputeUnitMount, mu: aoMessengerUnitMount })
+)(express())

--- a/servers/ur/src/config.js
+++ b/servers/ur/src/config.js
@@ -32,7 +32,8 @@ const serverConfigSchema = z.object({
     z.array(z.string().url())
   ),
   DUMP_PATH: z.string().min(1),
-  aoUnit: z.enum(['cu', 'mu'])
+  aoUnit: z.enum(['cu', 'mu']),
+  strategy: z.enum(['proxy', 'redirect'])
 })
 
 /**
@@ -52,14 +53,16 @@ const CONFIG_ENVS = {
      *
      * but should consider setting explicitly in your .env
      */
-    aoUnit: process.env.AO_UNIT || 'cu'
+    aoUnit: process.env.AO_UNIT || 'cu',
+    strategy: process.env.STRATEGY || 'proxy'
   },
   production: {
     MODE,
     port: process.env.PORT || 3005,
     hosts: process.env.HOSTS,
     DUMP_PATH: process.env.DUMP_PATH || tmpdir(),
-    aoUnit: process.env.AO_UNIT
+    aoUnit: process.env.AO_UNIT,
+    strategy: process.env.STRATEGY || 'proxy'
   }
 }
 

--- a/servers/ur/src/redirect.js
+++ b/servers/ur/src/redirect.js
@@ -1,0 +1,38 @@
+/**
+ * TODO: we could inject these, but just keeping simple for now
+ */
+import { determineHostWith } from './domain.js'
+import { logger } from './logger.js'
+
+import { mountRoutesWithByAoUnit } from './routes/byAoUnit.js'
+
+export function redirectWith ({ aoUnit, hosts }) {
+  const _logger = logger.child('redirect')
+  _logger('Configuring to redirect ao %s units...', aoUnit)
+
+  const determineHost = determineHostWith({ hosts })
+
+  /**
+   * A middleware that will redirect the request to the host determined
+   * by the injected business logic.
+   */
+  const redirectHandler = ({ processIdFromRequest }) => {
+    return async (req, res) => {
+      const processId = await processIdFromRequest(req)
+      const host = determineHost({ processId })
+
+      _logger('Redirecting process %s to host %s', processId, host)
+
+      // https://expressjs.com/en/api.html#req.originalUrl
+      const location = new URL(req.originalUrl, host)
+      res.redirect(307, location)
+    }
+  }
+
+  const mountRoutesWith = mountRoutesWithByAoUnit[aoUnit]
+
+  return (app) => {
+    mountRoutesWith({ app, middleware: redirectHandler })
+    return app
+  }
+}

--- a/servers/ur/src/routes/byAoUnit.js
+++ b/servers/ur/src/routes/byAoUnit.js
@@ -1,0 +1,7 @@
+import { mountCuRoutesWith } from './cu.js'
+import { mountMuRoutesWith } from './mu.js'
+
+export const mountRoutesWithByAoUnit = {
+  cu: mountCuRoutesWith,
+  mu: mountMuRoutesWith
+}

--- a/servers/ur/src/routes/cu.js
+++ b/servers/ur/src/routes/cu.js
@@ -1,0 +1,11 @@
+/**
+ * The Reverse Proxy Configuration for an ao Compute Unit Router
+ */
+export function mountCuRoutesWith ({ app, middleware }) {
+  app.get('/', middleware({ processIdFromRequest: () => 'process' }))
+  app.get('/result/:messageTxId', middleware({ processIdFromRequest: (req) => req.query['process-id'] }))
+  app.get('/results/:processId', middleware({ processIdFromRequest: (req) => req.params.processId }))
+  app.get('/state/:processId', middleware({ processIdFromRequest: (req) => req.params.processId }))
+  app.get('/cron/:processId', middleware({ processIdFromRequest: (req) => req.params.processId }))
+  app.post('/dry-run', middleware({ processIdFromRequest: (req) => req.query['process-id'] }))
+}

--- a/servers/ur/src/routes/mu.js
+++ b/servers/ur/src/routes/mu.js
@@ -1,0 +1,60 @@
+import { Readable } from 'node:stream'
+
+import express from 'express'
+import { DataItem } from 'warp-arbundles'
+
+/**
+ * The Reverse Proxy Configuration for an ao Messenger Unit Router
+ */
+export function mountMuRoutesWith ({ app, middleware }) {
+  class InvalidDataItemError extends Error {
+    constructor (...args) {
+      super(...args)
+      this.status = 422
+    }
+  }
+
+  const isTagEqualTo = ({ name, value }) => (tag) => tag.name === name && tag.value === value
+  const isMessage = (dataItem) => !!dataItem.tags.find(isTagEqualTo({ name: 'Type', value: 'Message' }))
+  const isProcess = (dataItem) => !!dataItem.tags.find(isTagEqualTo({ name: 'Type', value: 'Process' }))
+
+  app.get('/', (req, res, next) => {
+    if (req.query.debug) return res.status(501).send('MU Tracing not implemented on the Router')
+
+    /**
+     * Continue the request, rev proxying with a static value in order to get the route info response from a MU
+     */
+    return middleware({ processIdFromRequest: () => 'process' })(req, res, next)
+  })
+
+  /**
+   * Since the MU receives opaque data items, we have to unpack it, to know which MU
+   * to route to
+   */
+  app.post('/', express.raw({ type: 'application/octet-stream', limit: '10mb' }), middleware({
+    processIdFromRequest: async (req) => {
+      const dataItem = new DataItem(Buffer.from(req.body))
+
+      if (!(await dataItem.isValid())) throw new InvalidDataItemError('A valid and signed data item must be provided as the body')
+      /**
+       * The processId is the target on a message data item
+       */
+      if (isMessage(dataItem)) return dataItem.target
+      /**
+       * The processId is the dataItem itself on a process data item
+       */
+      if (isProcess(dataItem)) return dataItem.id
+
+      throw new InvalidDataItemError('Could not determine ao type of DataItem based on tag \'Type\'')
+    },
+    /**
+     * Since we consumed the request stream in order to parse the data item and
+     * determine the processId, we must provide a new request stream, to be sent
+     * as the body on proxied request
+     */
+    restreamBody: (req) => Readable.from(req.body)
+  }))
+
+  app.post('/monitor/:processId', middleware({ processIdFromRequest: (req) => req.params.processId }))
+  app.delete('/monitor/:processId', middleware({ processIdFromRequest: (req) => req.params.processId }))
+}


### PR DESCRIPTION
Adds `STRATEGY` environment variable, with default value of `proxy`. This maintains the current behavior.

With `STRATEGY=redirect`, the UR to return HTTP 307 redirects instead.

Closes #539.