### PR TITLE
fix(scheduler-utils): do not cache the redirected url in the byOwner cache

### DIFF
--- a/scheduler-utils/README.md
+++ b/scheduler-utils/README.md
@@ -50,6 +50,19 @@ import { locate } from "@permaweb/ao-scheduler-utils";
 let { url, address } = await locate('<process-id>');
 ```
 
+If you already know the `Scheduler` used by the process, you can provide it as a second parameter to `locate` as `schedulerHint`:
+
+```js
+import { locate } from "@permaweb/ao-scheduler-utils";
+
+let { url, address } = await locate('<process-id>', 'scheduler-owner-id');
+```
+
+This will skip querying the gateway for the process, in order to obtain it's `Scheduler` tag, and instead will directly query for the `Scheduler-Location` record.
+
+> This is useful when a process has just been spawned, so might not be indexed by the gateway yet.
+
+
 #### `validate`
 
 Check whether the wallet address is a valid `ao` Scheduler

--- a/scheduler-utils/src/locate.test.js
+++ b/scheduler-utils/src/locate.test.js
@@ -16,6 +16,7 @@ describe('locateWith', () => {
         assert.equal(process, PROCESS)
         return { url: DOMAIN, ttl: TEN_MS, owner: SCHEDULER }
       },
+      loadScheduler: async () => assert.fail('should not load the scheduler if no hint'),
       cache: {
         getByProcess: async (process) => {
           assert.equal(process, PROCESS)
@@ -45,11 +46,15 @@ describe('locateWith', () => {
       loadProcessScheduler: async () => {
         assert.fail('should never call on chain if in cache')
       },
+      loadScheduler: async () => assert.fail('should not load the scheduler if no hint'),
       cache: {
         getByProcess: async (process) => {
           assert.equal(process, PROCESS)
           return { url: DOMAIN, address: SCHEDULER }
-        }
+        },
+        getByOwner: async () => assert.fail('should not check cache by owner if cached by process'),
+        setByProcess: async () => assert.fail('should not set cache by process if cached by process'),
+        setByOwner: async () => assert.fail('should not set cache by owner if cached by process')
       }
     })
 
@@ -63,6 +68,7 @@ describe('locateWith', () => {
         assert.equal(process, PROCESS)
         return { url: DOMAIN, ttl: TEN_MS, owner: SCHEDULER }
       },
+      loadScheduler: async () => assert.fail('should not load the scheduler if no hint'),
       cache: {
         getByProcess: async (process) => {
           assert.equal(process, PROCESS)
@@ -92,6 +98,82 @@ describe('locateWith', () => {
     })
 
     await locate(PROCESS)
+      .then((res) => assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER }))
+  })
+
+  test('should use the scheduler hint and skip querying for the process', async () => {
+    const locate = locateWith({
+      loadProcessScheduler: async () => assert.fail('should not load process if given a scheduler hint'),
+      loadScheduler: async (owner) => {
+        assert.equal(owner, SCHEDULER)
+        return { url: DOMAIN, ttl: TEN_MS, owner: SCHEDULER }
+      },
+      cache: {
+        getByProcess: async (process) => {
+          assert.equal(process, PROCESS)
+          return undefined
+        },
+        getByOwner: async (owner) => {
+          assert.equal(owner, SCHEDULER)
+          return undefined
+        },
+        setByProcess: async (process, { url, address }, ttl) => {
+          assert.equal(process, PROCESS)
+          assert.equal(url, DOMAIN_REDIRECT)
+          assert.equal(address, SCHEDULER)
+          assert.equal(ttl, TEN_MS)
+        },
+        setByOwner: async (owner, url, ttl) => {
+          assert.equal(owner, SCHEDULER)
+          /**
+           * Original DOMAIN not the redirect
+           */
+          assert.equal(url, DOMAIN)
+          assert.equal(ttl, TEN_MS)
+        }
+      },
+      followRedirects: true,
+      checkForRedirect: async (url, process) => {
+        assert.equal(process, PROCESS)
+        assert.equal(url, DOMAIN)
+        return DOMAIN_REDIRECT
+      }
+    })
+
+    await locate(PROCESS, SCHEDULER)
+      .then((res) => assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER }))
+  })
+
+  test('should use the scheduler hint and use the cached owner', async () => {
+    const locate = locateWith({
+      loadProcessScheduler: async () => assert.fail('should not load process if given a scheduler hint'),
+      loadScheduler: async () => assert.fail('should not load the scheduler if cached'),
+      cache: {
+        getByProcess: async (process) => {
+          assert.equal(process, PROCESS)
+          return undefined
+        },
+        getByOwner: async (owner) => {
+          assert.equal(owner, SCHEDULER)
+          return { url: DOMAIN, ttl: TEN_MS, owner: SCHEDULER }
+        },
+        setByProcess: async (process, { url, address }, ttl) => {
+          assert.equal(process, PROCESS)
+          assert.equal(url, DOMAIN_REDIRECT)
+          assert.equal(address, SCHEDULER)
+          assert.equal(ttl, TEN_MS)
+        },
+        setByOwner: async () => assert.fail('should not cache by owner if cached')
+      },
+      followRedirects: true,
+      checkForRedirect: async (url, process) => {
+        assert.equal(process, PROCESS)
+        assert.equal(url, DOMAIN)
+        return DOMAIN_REDIRECT
+      }
+    })
+
+    await locate(PROCESS, SCHEDULER)
       .then((res) => assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER }))
   })
 })

--- a/scheduler-utils/src/locate.test.js
+++ b/scheduler-utils/src/locate.test.js
@@ -76,7 +76,10 @@ describe('locateWith', () => {
         },
         setByOwner: async (owner, url, ttl) => {
           assert.equal(owner, SCHEDULER)
-          assert.equal(url, DOMAIN_REDIRECT)
+          /**
+           * Original DOMAIN not the redirect
+           */
+          assert.equal(url, DOMAIN)
           assert.equal(ttl, TEN_MS)
         }
       },


### PR DESCRIPTION
This was the root cause of #543 

The url obtained from the redirect, which is process specific, was being cached for the `owner`. So when calling `raw` on `scheduler-utils`, it was returning the cached redirected url for the specific process. This would cause subsequent processes to `404` on the scheduler.

This PR also adds the ability to provide a`schedulerHint` to `locate`, which will cause it to skip querying for the process, and instead query directly for the `Scheduler-Location`, utilizing it's internal in memory cache.