### PR TITLE
feat(cu): implement Assignment type handling #556

### DIFF
--- a/servers/cu/src/domain/index.js
+++ b/servers/cu/src/domain/index.js
@@ -201,6 +201,14 @@ export const createApis = async (ctx) => {
     locateProcess: locateDataloader.load.bind(locateDataloader),
     doesExceedModuleMaxMemory: WasmClient.doesExceedModuleMaxMemoryWith({ PROCESS_WASM_MEMORY_MAX_LIMIT: ctx.PROCESS_WASM_MEMORY_MAX_LIMIT }),
     doesExceedModuleMaxCompute: WasmClient.doesExceedModuleMaxComputeWith({ PROCESS_WASM_COMPUTE_MAX_LIMIT: ctx.PROCESS_WASM_COMPUTE_MAX_LIMIT }),
+    /**
+     * This is not configurable, as Load message support will be dictated by the protocol,
+     * which proposes Assignments as a more flexible and extensible solution that also includes
+     * Load Message use-cases
+     *
+     * But for now, supporting Load messages in perpetuity.
+     */
+    AO_LOAD_MAX_BLOCK: Number.MAX_SAFE_INTEGER,
     logger
   })
   /**

--- a/servers/cu/src/domain/utils.js
+++ b/servers/cu/src/domain/utils.js
@@ -135,6 +135,11 @@ export function mapForwardedBy ({ tags, owner }) {
   return owner
 }
 
+export function isAssignment ({ tags }) {
+  const tag = findRawTag('Type', tags)
+  return tag && tag.value === 'Assignment'
+}
+
 /**
 * Parse tags into a object with key-value pairs of name -> values.
 *


### PR DESCRIPTION
Closes #556 

Also puts in place a strategy to deprecate `Load` messages, supporting them until a TBD block height.