### PR TITLE
Implement Assignment `aopv0.1` in CU

### DIFF
--- a/servers/cu/src/domain/client/ao-su.test.js
+++ b/servers/cu/src/domain/client/ao-su.test.js
@@ -3,9 +3,140 @@ import { describe, test } from 'node:test'
 import assert from 'node:assert'
 
 import { loadMessageMetaSchema } from '../dal.js'
-import { loadMessageMetaWith } from './ao-su.js'
+import { loadMessageMetaWith, mapNode } from './ao-su.js'
+import { messageSchema } from '../model.js'
+
+const withoutAoGlobal = messageSchema.omit({ AoGlobal: true })
 
 describe('ao-su', () => {
+  describe('mapNode', () => {
+    const now = new Date().getTime()
+    const messageId = 'message-123'
+    const assignedMessageId = 'assigned-123'
+    const expected = {
+      cron: undefined,
+      ordinate: '23',
+      name: `Scheduled Message ${messageId} ${now}:23`,
+      message: {
+        Id: messageId,
+        Signature: 'sig-123',
+        Data: 'data-123',
+        Owner: 'owner-123',
+        Target: 'process-123',
+        Anchor: '00000000123',
+        From: 'owner-123',
+        'Forwarded-By': undefined,
+        Tags: [{ name: 'Foo', value: 'Bar' }],
+        Epoch: 0,
+        Nonce: 23,
+        Timestamp: now,
+        'Block-Height': 123,
+        'Hash-Chain': 'hash-123',
+        Cron: false
+      },
+      block: {
+        height: 123,
+        timestamp: now
+      }
+    }
+
+    test('should map the legacy shape', () => {
+      const res = mapNode({
+        message: {
+          id: messageId,
+          tags: [{ name: 'Foo', value: 'Bar' }],
+          signature: 'sig-123',
+          anchor: '00000000123'
+        },
+        block: '000000000123',
+        owner: {
+          address: 'owner-123',
+          key: 'key-123'
+        },
+        process_id: 'process-123',
+        data: 'data-123',
+        epoch: 0,
+        nonce: 23,
+        timestamp: now,
+        hash_chain: 'hash-123'
+      })
+      assert.deepStrictEqual(
+        withoutAoGlobal.parse(res),
+        withoutAoGlobal.parse(expected)
+      )
+    })
+
+    test('should map the current shape', () => {
+      const res = mapNode({
+        message: {
+          id: messageId,
+          tags: [{ name: 'Foo', value: 'Bar' }],
+          signature: 'sig-123',
+          anchor: '00000000123',
+          owner: {
+            address: 'owner-123',
+            key: 'key-123'
+          },
+          data: 'data-123'
+        },
+        assignment: {
+          owner: {
+            address: 'su-123',
+            key: 'su-123'
+          },
+          tags: [
+            { name: 'Epoch', value: '0' },
+            { name: 'Nonce', value: '23' },
+            { name: 'Process', value: 'process-123' },
+            { name: 'Block-Height', value: '000000000123' },
+            { name: 'Timestamp', value: `${now}` },
+            { name: 'Hash-Chain', value: 'hash-123' }
+          ],
+          data: 'su-data-123'
+        }
+      })
+      assert.deepStrictEqual(
+        withoutAoGlobal.parse(res),
+        withoutAoGlobal.parse(expected)
+      )
+      assert.equal(res.isAssignment, false)
+    })
+
+    test('should set isAssignment to true message.Id to assignment Message tag if an assignment of message on-chain', () => {
+      const res = mapNode({
+        message: null,
+        assignment: {
+          owner: {
+            address: 'su-123',
+            key: 'su-123'
+          },
+          tags: [
+            { name: 'Epoch', value: '0' },
+            { name: 'Nonce', value: '23' },
+            { name: 'Process', value: 'process-123' },
+            { name: 'Block-Height', value: '000000000123' },
+            { name: 'Timestamp', value: `${now}` },
+            { name: 'Hash-Chain', value: 'hash-123' },
+            { name: 'Message', value: assignedMessageId }
+          ],
+          data: 'su-data-123'
+        }
+      })
+      assert.deepStrictEqual(res.message, {
+        Id: assignedMessageId,
+        Message: assignedMessageId,
+        Target: 'process-123',
+        Epoch: 0,
+        Nonce: 23,
+        Timestamp: now,
+        'Block-Height': 123,
+        'Hash-Chain': 'hash-123',
+        Cron: false
+      })
+      assert.ok(res.isAssignment)
+    })
+  })
+
   describe('loadMessageMetaWith', () => {
     test('return the message meta', async () => {
       const loadMessageMeta = loadMessageMetaSchema.implement(

--- a/servers/cu/src/domain/client/ao-su.test.js
+++ b/servers/cu/src/domain/client/ao-su.test.js
@@ -142,9 +142,44 @@ describe('ao-su', () => {
       const loadMessageMeta = loadMessageMetaSchema.implement(
         loadMessageMetaWith({
           fetch: async (url, options) => {
-            assert.equal(url, 'https://ao-su-1.onrender.com/message-tx-123?process-id=process-123')
+            assert.equal(url, 'https://foo.bar/message-tx-123?process-id=process-123')
             assert.deepStrictEqual(options, { method: 'GET' })
 
+            return new Response(JSON.stringify({
+              message: {}, // not used, but will be present
+              assignment: {
+                tags: [
+                  { name: 'Process', value: 'process-123' },
+                  { name: 'Nonce', value: '3' },
+                  { name: 'Timestamp', value: '12345' }
+                ]
+              }
+            }))
+          }
+        })
+      )
+
+      const res = await loadMessageMeta({
+        suUrl: 'https://foo.bar',
+        processId: 'process-123',
+        messageTxId: 'message-tx-123'
+      })
+
+      assert.deepStrictEqual(res, {
+        processId: 'process-123',
+        timestamp: 12345,
+        nonce: 3
+      })
+    })
+
+    test('return the message meta from legacy shape', async () => {
+      const loadMessageMeta = loadMessageMetaSchema.implement(
+        loadMessageMetaWith({
+          fetch: async (url, options) => {
+            assert.equal(url, 'https://foo.bar/message-tx-123?process-id=process-123')
+            assert.deepStrictEqual(options, { method: 'GET' })
+
+            // legacy response shape from SU call
             return new Response(JSON.stringify({
               process_id: 'process-123',
               timestamp: 12345,
@@ -155,7 +190,7 @@ describe('ao-su', () => {
       )
 
       const res = await loadMessageMeta({
-        suUrl: 'https://ao-su-1.onrender.com',
+        suUrl: 'https://foo.bar',
         processId: 'process-123',
         messageTxId: 'message-tx-123'
       })

--- a/servers/cu/src/domain/client/worker.js
+++ b/servers/cu/src/domain/client/worker.js
@@ -255,6 +255,7 @@ export function evaluateWith ({
       ),
       Error: pathOr(undefined, ['Error']),
       Messages: pathOr([], ['Messages']),
+      Assignments: pathOr([], ['Assignments']),
       Spawns: pathOr([], ['Spawns']),
       Output: pipe(
         pathOr('', ['Output']),

--- a/servers/cu/src/domain/client/worker.test.js
+++ b/servers/cu/src/domain/client/worker.test.js
@@ -77,6 +77,11 @@ describe('worker', async () => {
         assert.deepStrictEqual(output.Messages, [expectedMessage])
       })
 
+      test('returns assignments', async () => {
+        const output = await evaluate(args)
+        assert.deepStrictEqual(output.Assignments, [])
+      })
+
       test('returns spawns', async () => {
         const expectedSpawn = {
           Owner: 'owner-123',

--- a/servers/cu/src/domain/index.js
+++ b/servers/cu/src/domain/index.js
@@ -201,6 +201,14 @@ export const createApis = async (ctx) => {
     locateProcess: locateDataloader.load.bind(locateDataloader),
     doesExceedModuleMaxMemory: WasmClient.doesExceedModuleMaxMemoryWith({ PROCESS_WASM_MEMORY_MAX_LIMIT: ctx.PROCESS_WASM_MEMORY_MAX_LIMIT }),
     doesExceedModuleMaxCompute: WasmClient.doesExceedModuleMaxComputeWith({ PROCESS_WASM_COMPUTE_MAX_LIMIT: ctx.PROCESS_WASM_COMPUTE_MAX_LIMIT }),
+    /**
+     * This is not configurable, as Load message support will be dictated by the protocol,
+     * which proposes Assignments as a more flexible and extensible solution that also includes
+     * Load Message use-cases
+     *
+     * But for now, supporting Load messages in perpetuity.
+     */
+    AO_LOAD_MAX_BLOCK: Number.MAX_SAFE_INTEGER,
     logger
   })
   /**

--- a/servers/cu/src/domain/lib/evaluate.js
+++ b/servers/cu/src/domain/lib/evaluate.js
@@ -113,6 +113,7 @@ export function evaluateWith (env) {
           Memory: pathOr(null, ['result', 'Memory']),
           Error: pathOr(undefined, ['result', 'Error']),
           Messages: pathOr([], ['result', 'Messages']),
+          Assignments: pathOr([], ['result', 'Assignments']),
           Spawns: pathOr([], ['result', 'Spawns']),
           Output: pathOr('', ['result', 'Output']),
           GasUsed: pathOr(undefined, ['result', 'GasUsed']),

--- a/servers/cu/src/domain/lib/gatherResults.js
+++ b/servers/cu/src/domain/lib/gatherResults.js
@@ -112,6 +112,7 @@ export function gatherResultsWith (env) {
                      */
                     applySpec({
                       Messages: pathOr([], ['Messages']),
+                      Assignments: pathOr([], ['Assignments']),
                       Spawns: pathOr([], ['Spawns']),
                       Output: pathOr(undefined, ['Output']),
                       Error: pathOr(undefined, ['Error'])

--- a/servers/cu/src/domain/lib/hydrateMessages.js
+++ b/servers/cu/src/domain/lib/hydrateMessages.js
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import WarpArBundles from 'warp-arbundles'
 
 import { loadTransactionDataSchema, loadTransactionMetaSchema } from '../dal.js'
-import { streamSchema } from '../model.js'
+import { messageSchema, streamSchema } from '../model.js'
 import { findRawTag } from '../utils.js'
 
 const { createData } = WarpArBundles
@@ -21,6 +21,38 @@ const { createData } = WarpArBundles
 const ctxSchema = z.object({
   messages: streamSchema
 }).passthrough()
+
+function loadFromChainWith ({ loadTransactionData, loadTransactionMeta }) {
+  loadTransactionData = loadTransactionDataSchema.implement(loadTransactionData)
+  loadTransactionMeta = loadTransactionMetaSchema.implement(loadTransactionMeta)
+
+  return async (id, encodeData) => Promise.all([
+    loadTransactionData(id)
+      .then(res => res.arrayBuffer())
+      .then((ab) => Buffer.from(ab)),
+    loadTransactionMeta(id)
+  ])
+  /**
+   * Construct the JSON representation of a DataItem using
+   * raw transaction data, and metadata about the
+   * transactions (in the shape of a GQL Gateway Transaction)
+   */
+    .then(async ([data, meta]) => ({
+      Id: meta.id,
+      Signature: meta.signature,
+      Owner: meta.owner.address,
+      From: meta.owner.address,
+      Tags: meta.tags,
+      Anchor: meta.anchor,
+      /**
+       * Encode the array buffer of the raw data as base64, if desired.
+       *
+       * TODO: should data always be a buffer, or should cu use Content-Type
+       * tag to parse data? ie. json, text, etc.
+       */
+      Data: encodeData ? bytesToBase64(data) : data
+    }))
+}
 
 /**
  * Converts an arraybuffer into base64, also handling
@@ -94,28 +126,12 @@ export function maybeMessageIdWith ({ logger }) {
   }
 }
 
-export function maybeAoLoadWith ({ loadTransactionData, loadTransactionMeta, logger }) {
-  loadTransactionData = loadTransactionDataSchema.implement(loadTransactionData)
-  loadTransactionMeta = loadTransactionMetaSchema.implement(loadTransactionMeta)
-
-  /**
-   * Construct the JSON representation of a DataItem using
-   * raw transaction data, and metadata about the
-   * transactions (in the shape of a GQL Gateway Transaction)
-   */
-  function messageFromParts ({ data, meta }) {
-    return {
-      Id: meta.id,
-      Signature: meta.signature,
-      Owner: meta.owner.address,
-      Tags: meta.tags,
-      Anchor: meta.anchor,
-      /**
-       * Encode the array buffer of the raw data as base64
-       */
-      Data: bytesToBase64(data)
-    }
-  }
+/**
+ * @deprecated Load messages will be replaced by Assignments of on-chain messages.
+ * Keeping code here, to be deactivated at block AO_LOAD_MAX_BLOCK
+ */
+export function maybeAoLoadWith ({ loadTransactionData, loadTransactionMeta, AO_LOAD_MAX_BLOCK, logger }) {
+  const loadFromChain = loadFromChainWith({ loadTransactionData, loadTransactionMeta })
 
   return async function * maybeAoLoad (messages) {
     for await (const cur of messages) {
@@ -123,23 +139,48 @@ export function maybeAoLoadWith ({ loadTransactionData, loadTransactionMeta, log
       /**
        * Either a cron message or not an ao-load message, so no work is needed
        */
-      if (!tag || cur.message.Cron) {
-        yield cur
+      if (!tag || cur.message.Cron) { yield cur; continue }
+
+      /**
+       * TODO: should this use the actual current block height,
+       * or the block height at the time of scheduling (which is what is currently being checked)
+       */
+      if (cur.block.height >= AO_LOAD_MAX_BLOCK) {
+        logger(
+          'Load message "%s" scheduled after block %d. Removing message from eval stream and skipping...',
+          cur.message.name,
+          AO_LOAD_MAX_BLOCK
+        )
         continue
       }
-
-      // logger('Hydrating Load message for "%s" from transaction "%s"', cur.message.Id, tag.value)
       /**
-       * - Fetch raw data and meta from gateway
-       * - contruct the data item JSON, encoding the raw data as base64
-       * - set as 'data' on the ao-load message
+       * set as 'data' on the ao-load message
        */
-      cur.message.Data = await Promise.all([
-        loadTransactionData(tag.value).then(res => res.arrayBuffer()),
-        loadTransactionMeta(tag.value)
-      ]).then(([data, meta]) => messageFromParts({ data, meta }))
+      cur.message.Data = await loadFromChain(tag.value, true)
 
-      // logger('Hydrated Load message for "%s" from transaction "%s" and attached as data', cur.message.Id, tag.value)
+      yield cur
+    }
+  }
+}
+
+export function maybeAoAssignmentWith ({ loadTransactionData, loadTransactionMeta }) {
+  const loadFromChain = loadFromChainWith({ loadTransactionData, loadTransactionMeta })
+
+  return async function * maybeAoAssignment (messages) {
+    for await (const cur of messages) {
+      /**
+       * Not an Assignment so nothing to do
+       */
+      if (!cur.isAssignment) { yield cur; continue }
+
+      /**
+       * The values are loaded from chain and used to overwrite
+       * the specific fields on the message
+       *
+       * TODO: should Owner be overwritten? If so, what about From?
+       * currently, this will overwrite both, set to the owner of the message on-chain
+       */
+      cur.message = mergeRight(cur.message, await loadFromChain(cur.message.Id))
 
       yield cur
     }
@@ -166,6 +207,7 @@ export function hydrateMessagesWith (env) {
 
   const maybeMessageId = maybeMessageIdWith(env)
   const maybeAoLoad = maybeAoLoadWith(env)
+  const maybeAoAssignment = maybeAoAssignmentWith(env)
 
   return (ctx) => {
     return of(ctx)
@@ -188,7 +230,12 @@ export function hydrateMessagesWith (env) {
         return composeStreams(
           $messages,
           Transform.from(maybeMessageId),
-          Transform.from(maybeAoLoad)
+          Transform.from(maybeAoLoad),
+          Transform.from(maybeAoAssignment),
+          // Ensure every message emitted satisfies the schema
+          Transform.from(async function * (messages) {
+            for await (const cur of messages) yield messageSchema.parse(cur)
+          })
         )
       })
       .map(messages => ({ messages }))

--- a/servers/cu/src/domain/lib/hydrateMessages.test.js
+++ b/servers/cu/src/domain/lib/hydrateMessages.test.js
@@ -305,9 +305,7 @@ describe('hydrateMessages', () => {
           ],
           Owner: 'owner-123',
           From: 'owner-123',
-          Data: await new Response('Hello World 🤖❌⚡️')
-            .arrayBuffer()
-            .then((ab) => Buffer.from(ab))
+          Data: 'Hello World 🤖❌⚡️'
         }
       })
     })

--- a/servers/cu/src/domain/lib/hydrateMessages.test.js
+++ b/servers/cu/src/domain/lib/hydrateMessages.test.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-throw-literal */
-import { describe, test } from 'node:test'
+import { describe, test, before } from 'node:test'
 import assert from 'node:assert'
 
 import { createLogger } from '../logger.js'
-import { bytesToBase64, maybeAoLoadWith, maybeMessageIdWith } from './hydrateMessages.js'
+import { bytesToBase64, maybeAoAssignmentWith, maybeAoLoadWith, maybeMessageIdWith } from './hydrateMessages.js'
 
 const logger = createLogger('ao-cu:readState')
 
@@ -91,88 +91,118 @@ describe('hydrateMessages', () => {
     })
   })
 
+  /**
+   * @deprecated - Load messages are deprecated, but keeping the
+   * test as long as the functionality is supported
+   */
   describe('maybeAoLoadWith', () => {
-    test('should build the ao-load message', async () => {
-      const notAoLoad = {
-        message: {
-          Id: 'message-tx-345',
-          Signature: 'sig-345',
-          Owner: 'owner-345',
-          Tags: [
-            { name: 'Data-Protocol', value: 'ao' },
-            { name: 'Type', value: 'Message' },
-            { name: 'function', value: 'notify' }
-          ],
-          Data: 'foobar'
+    const notAoLoad = {
+      message: {
+        Id: 'message-tx-345',
+        Signature: 'sig-345',
+        Owner: 'owner-345',
+        Tags: [
+          { name: 'Data-Protocol', value: 'ao' },
+          { name: 'Type', value: 'Message' },
+          { name: 'function', value: 'notify' }
+        ],
+        Data: 'foobar'
+      }
+    }
+    const cronMessage = {
+      message: {
+        Id: 'message-tx-345',
+        Signature: 'sig-345',
+        Owner: 'owner-345',
+        Tags: [
+          { name: 'Data-Protocol', value: 'ao' },
+          { name: 'Type', value: 'Message' },
+          { name: 'function', value: 'notify' }
+        ],
+        Data: 'foobar',
+        Cron: true
+      }
+    }
+    const aoLoad = {
+      message: {
+        Id: 'message-tx-456',
+        Signature: 'sig-456',
+        Owner: 'owner-456',
+        Tags: [
+          { name: 'Data-Protocol', value: 'ao' },
+          { name: 'Type', value: 'Message' },
+          { name: 'function', value: 'notify' },
+          { name: 'Load', value: 'message-tx-123' }
+        ],
+        Data: 'overwritten'
+      },
+      block: { height: 99 }
+    }
+    const aoLoadAfterMaxBlock = {
+      message: {
+        Id: 'message-tx-999',
+        Signature: 'sig-999',
+        Owner: 'owner-999',
+        Tags: [
+          { name: 'Data-Protocol', value: 'ao' },
+          { name: 'Type', value: 'Message' },
+          { name: 'function', value: 'notify' },
+          { name: 'Load', value: 'message-tx-123' }
+        ],
+        Data: 'overwritten'
+      },
+      block: { height: 100 }
+    }
+
+    async function * messageStream () {
+      yield notAoLoad
+      yield aoLoad
+      yield aoLoadAfterMaxBlock
+      yield cronMessage
+    }
+
+    const maybeAoLoad = maybeAoLoadWith({
+      loadTransactionData: async (id) => {
+        assert.equal(id, 'message-tx-123')
+        return new Response('Hello World 🤖❌⚡️')
+      },
+      loadTransactionMeta: async (id) => {
+        assert.equal(id, 'message-tx-123')
+        return {
+          id: 'message-tx-123',
+          signature: 'sig-123',
+          anchor: 'anchor-123',
+          owner: {
+            address: 'owner-123'
+          },
+          tags: [
+            { name: 'foo', value: 'bar' }
+          ]
         }
-      }
-      const cronMessage = {
-        message: {
-          Id: 'message-tx-345',
-          Signature: 'sig-345',
-          Owner: 'owner-345',
-          Tags: [
-            { name: 'Data-Protocol', value: 'ao' },
-            { name: 'Type', value: 'Message' },
-            { name: 'function', value: 'notify' }
-          ],
-          Data: 'foobar',
-          Cron: true
-        }
-      }
-      const aoLoad = {
-        message: {
-          Id: 'message-tx-456',
-          Signature: 'sig-456',
-          Owner: 'owner-456',
-          Tags: [
-            { name: 'Data-Protocol', value: 'ao' },
-            { name: 'Type', value: 'Message' },
-            { name: 'function', value: 'notify' },
-            { name: 'Load', value: 'message-tx-123' }
-          ],
-          Data: 'overwritten'
-        }
-      }
+      },
+      AO_LOAD_MAX_BLOCK: 100,
+      logger
+    })
 
-      async function * messageStream () {
-        yield notAoLoad
-        yield aoLoad
-        yield cronMessage
-      }
-
-      const maybeAoLoad = maybeAoLoadWith({
-        loadTransactionData: async (id) => {
-          assert.equal(id, 'message-tx-123')
-          return new Response('Hello World 🤖❌⚡️')
-        },
-        loadTransactionMeta: async (id) => {
-          assert.equal(id, 'message-tx-123')
-          return {
-            id: 'message-tx-123',
-            signature: 'sig-123',
-            anchor: 'anchor-123',
-            owner: {
-              address: 'owner-123'
-            },
-            tags: [
-              { name: 'foo', value: 'bar' }
-            ]
-          }
-        },
-        logger
-      })
-
-      const hydrated = maybeAoLoad(messageStream())
-
-      const messages = []
+    const hydrated = maybeAoLoad(messageStream())
+    const messages = []
+    before(async () => {
       for await (const message of hydrated) messages.push(message)
+    })
 
+    test('should filter out load messages after AO_LOAD_MAX_BLOCK', () => {
       assert.equal(messages.length, 3)
+    })
+
+    test('should emit the messages in same order', () => {
       const [one, two, three] = messages
       assert.deepStrictEqual(one, notAoLoad)
+      assert.equal(two.message.Id, aoLoad.message.Id)
       assert.deepStrictEqual(three, cronMessage)
+    })
 
+    test('should overwrite the data', async () => {
+      const [, two] = messages
       assert.deepStrictEqual(two, {
         ...aoLoad,
         message: {
@@ -182,12 +212,102 @@ describe('hydrateMessages', () => {
             Id: 'message-tx-123',
             Signature: 'sig-123',
             Owner: 'owner-123',
+            From: 'owner-123',
             Tags: [
               { name: 'foo', value: 'bar' }
             ],
             Anchor: 'anchor-123',
             Data: bytesToBase64(await new Response('Hello World 🤖❌⚡️').arrayBuffer())
           }
+        }
+      })
+    })
+  })
+
+  describe('maybeAoAssignmentWith', () => {
+    const notAssignment = {
+      message: {
+        Id: 'message-tx-345',
+        Signature: 'sig-345',
+        Owner: 'owner-345',
+        Tags: [
+          { name: 'Data-Protocol', value: 'ao' },
+          { name: 'Type', value: 'Message' },
+          { name: 'function', value: 'notify' }
+        ],
+        Data: 'foobar'
+      }
+    }
+    const aoAssignment = {
+      ordinate: 13,
+      isAssignment: true,
+      message: {
+        Id: 'message-tx-123',
+        Epoch: 0,
+        Nonce: 23,
+        'Block-Height': 123,
+        Timestamp: 123
+      },
+      block: { height: 99 }
+    }
+
+    async function * messageStream () {
+      yield notAssignment
+      yield aoAssignment
+      yield notAssignment
+    }
+
+    const maybeAoAssignment = maybeAoAssignmentWith({
+      loadTransactionData: async (id) => {
+        assert.equal(id, 'message-tx-123')
+        return new Response('Hello World 🤖❌⚡️')
+      },
+      loadTransactionMeta: async (id) => {
+        assert.equal(id, 'message-tx-123')
+        return {
+          id: 'message-tx-123',
+          signature: 'sig-123',
+          anchor: 'anchor-123',
+          owner: {
+            address: 'owner-123'
+          },
+          tags: [
+            { name: 'foo', value: 'bar' }
+          ]
+        }
+      }
+    })
+
+    const hydrated = maybeAoAssignment(messageStream())
+    const messages = []
+    before(async () => {
+      for await (const message of hydrated) messages.push(message)
+    })
+
+    test('should emit the messages in same order', () => {
+      const [one, two, three] = messages
+      assert.deepStrictEqual(one, notAssignment)
+      assert.equal(two.ordinate, aoAssignment.ordinate)
+      assert.deepStrictEqual(three, notAssignment)
+    })
+
+    test('should hydrate the message from on chain', async () => {
+      const [, two] = messages
+      assert.deepStrictEqual(two, {
+        ...aoAssignment,
+        message: {
+          ...aoAssignment.message,
+          // original fields overwritten with constructed data item
+          Signature: 'sig-123',
+          Anchor: 'anchor-123',
+          Tags: [
+            { name: 'foo', value: 'bar' }
+          ],
+          Owner: 'owner-123',
+          From: 'owner-123',
+          Data: await new Response('Hello World 🤖❌⚡️')
+            .arrayBuffer()
+            .then((ab) => Buffer.from(ab))
         }
       })
     })

--- a/servers/cu/src/domain/model.js
+++ b/servers/cu/src/domain/model.js
@@ -196,6 +196,10 @@ export const messageSchema = z.object({
    * A canonical name that can used for logging purposes
    */
   name: z.string(),
+  /**
+   * Whether the message is a pure assignment of an on-chain message
+   */
+  isAssignment: z.boolean().default(false),
   message: z.object({
     /**
      * The tx id of the message ie. the data item id

--- a/servers/cu/src/domain/model.js
+++ b/servers/cu/src/domain/model.js
@@ -309,13 +309,14 @@ export const evaluationSchema = z.object({
     z.date()
   ),
   /**
-   * ao processes return { Memory, Message, Spawns, Output, Error } }
+   * ao processes return { Memory, Message, Assignments, Spawns, Output, Error } }
    *
    * This is the output of process, after the action was applied
    */
   output: z.object({
     Memory: z.any().nullish(),
     Messages: z.array(z.any()).nullish(),
+    Assignments: z.array(z.any()).nullish(),
     Spawns: z.array(z.any()).nullish(),
     Output: z.any().nullish(),
     GasUsed: z.number().nullish(),


### PR DESCRIPTION
Closes #556 

This PR:

- implements `Assignment` message hydration according to `aopv0.1` 
  - If an `Assignment` references a message on chain, then the CU will download, and _overwrite_ ie. "hydrate" the message data to be sent to the process using the that data
  - Unlike `Load` messages
- Interop between legacy and new response shapes from SU, according to what's described in #563
  - loading meta aka. `Assignment` from the SU `/{messageTxId}?process-id=...`
  - loading process message stream `/{processTxId}?process-id=...`

The interoperability of legacy and new response shape will enable deploying the CUs separately, without a coordinated SU deployment. Then at any point, the SUs serving the new shape can be deployed, and the CU will "switch" to using the new mapping strategy. Finally, once everything is stable, the legacy mapping code can be removed from the CU as technical debt. (issue to track this will be created)