### PR TITLE
fix(mu): use graphql_url instead of gateway_url

### DIFF
--- a/servers/mu/.env.example
+++ b/servers/mu/.env.example
@@ -1,6 +1,6 @@
 PORT=3004
 CU_URL="https://cu.ao-testnet.xyz"
-GATEWAY_URL="https://arweave.net"
+GRAPHQL_URL="https://arweave.net/graphql"
 NODE_CONFIG_ENV="development"
 DEBUG=*
 PATH_TO_WALLET="/home/wallet.json"

--- a/servers/mu/README.md
+++ b/servers/mu/README.md
@@ -27,7 +27,7 @@ There are a few environment variables that you can set:
 - `CU_URL`: Which `ao` Compute Unit to use (defaults to
   `http://localhost:6363` in development mode)
 - `PORT`: Which port the web server should listen on (defaults to port `3005`)
-- `GATEWAY_URL`: an arweave gateway to use (defaults to https://arweave.net in development mode)
+- `GRAPHQL_URL`: The url for the Arweave Gateway GraphQL server to be used by the MU. (defaults to https://arweave.net/graphql)
 - `PATH_TO_WALLET`: the path to the wallet JWK interface you would like the `mu`
   to use to sign messages that it is pushing
 - `DEBUG`: if DEBUG=* or DEBUG=ao-mu* then verbose debug logs will be provided in the console.

--- a/servers/mu/cranker/src/config.js
+++ b/servers/mu/cranker/src/config.js
@@ -9,7 +9,7 @@ dotenv.config()
 export const configSchema = z.object({
   CU_URL: z.string().url('CU_URL must be a a valid URL'),
   MU_WALLET: z.record(z.any()),
-  GATEWAY_URL: z.string(),
+  GRAPHQL_URL: z.string(),
   UPLOADER_URL: z.string()
 })
 
@@ -25,14 +25,14 @@ const CONFIG_ENVS = {
     MODE,
     MU_WALLET: walletKey,
     CU_URL: process.env.CU_URL || 'https://cu.ao-testnet.xyz',
-    GATEWAY_URL: process.env.GATEWAY_URL || 'https://arweave.net',
+    GRAPHQL_URL: process.env.GRAPHQL_URL || 'https://arweave.net/graphql',
     UPLOADER_URL: process.env.UPLOADER_URL || 'https://up.arweave.net'
   },
   production: {
     MODE,
     MU_WALLET: walletKey,
     CU_URL: process.env.CU_URL,
-    GATEWAY_URL: process.env.GATEWAY_URL,
+    GRAPHQL_URL: process.env.GRAPHQL_URL || 'https://arweave.net/graphql',
     UPLOADER_URL: process.env.UPLOADER_URL || 'https://up.arweave.net'
   }
 }

--- a/servers/mu/cranker/src/index.common.js
+++ b/servers/mu/cranker/src/index.common.js
@@ -24,7 +24,7 @@ export const createApis = (ctx) => {
   const MU_WALLET = ctx.MU_WALLET
   const UPLOADER_URL = ctx.UPLOADER_URL
 
-  const { locate, raw } = schedulerUtilsConnect({ cacheSize: 100, GATEWAY_URL: ctx.GATEWAY_URL })
+  const { locate, raw } = schedulerUtilsConnect({ cacheSize: 100, GRAPHQL_URL: ctx.GRAPHQL_URL })
 
   const logger = ctx.logger
 

--- a/servers/mu/src/config.js
+++ b/servers/mu/src/config.js
@@ -48,7 +48,7 @@ const CONFIG_ENVS = {
     port: process.env.PORT || 3005,
     MU_WALLET: walletKey,
     CU_URL: process.env.CU_URL || 'http://localhost:6363',
-    GATEWAY_URL: process.env.GATEWAY_URL || 'https://arweave.net',
+    GRAPHQL_URL: process.env.GRAPHQL_URL || 'https://arweave.net/graphql',
     SCHEDULED_INTERVAL: process.env.SCHEDULED_INTERVAL || 500,
     DUMP_PATH: process.env.DUMP_PATH || '',
     UPLOADER_URL: process.env.UPLOADER_URL || 'https://up.arweave.net'
@@ -58,7 +58,7 @@ const CONFIG_ENVS = {
     port: process.env.PORT || 3005,
     MU_WALLET: walletKey,
     CU_URL: process.env.CU_URL,
-    GATEWAY_URL: process.env.GATEWAY_URL,
+    GRAPHQL_URL: process.env.GRAPHQL_URL || 'https://arweave.net/graphql',
     SCHEDULED_INTERVAL: process.env.SCHEDULED_INTERVAL || 500,
     DUMP_PATH: process.env.DUMP_PATH || '',
     UPLOADER_URL: process.env.UPLOADER_URL || 'https://up.arweave.net'

--- a/servers/mu/src/domain/index.js
+++ b/servers/mu/src/domain/index.js
@@ -31,7 +31,7 @@ export const domainConfigSchema = z.object({
   MU_WALLET: z.record(z.any()),
   SCHEDULED_INTERVAL: z.number(),
   DUMP_PATH: z.string(),
-  GATEWAY_URL: z.string(),
+  GRAPHQL_URL: z.string(),
   UPLOADER_URL: z.string()
 })
 
@@ -43,8 +43,8 @@ export const createApis = (ctx) => {
   const logger = ctx.logger
   const fetch = ctx.fetch
 
-  const { locate, raw } = schedulerUtilsConnect({ cacheSize: 500, GATEWAY_URL: ctx.GATEWAY_URL, followRedirects: true })
-  const { locate: locateNoRedirect } = schedulerUtilsConnect({ cacheSize: 500, GATEWAY_URL: ctx.GATEWAY_URL, followRedirects: false })
+  const { locate, raw } = schedulerUtilsConnect({ cacheSize: 500, GRAPHQL_URL: ctx.GRAPHQL_URL, followRedirects: true })
+  const { locate: locateNoRedirect } = schedulerUtilsConnect({ cacheSize: 500, GRAPHQL_URL: ctx.GRAPHQL_URL, followRedirects: false })
 
   const cache = InMemoryClient.createLruCache({ size: 500 })
   const getByProcess = InMemoryClient.getByProcessWith({ cache })


### PR DESCRIPTION
This change is brought about by changes in scheduler-utils@0.0.16.

And we're mimicing similar changes in the CU.