### PR TITLE
fix: fix issues in locate.js, locate.test.js and in-memory.js for sch…

### DIFF
--- a/scheduler-utils/src/client/in-memory.js
+++ b/scheduler-utils/src/client/in-memory.js
@@ -52,6 +52,6 @@ export function getByOwnerWith ({ cache = internalCache }) {
 export function setByOwnerWith ({ cache = internalCache }) {
   return async (owner, url, ttl) => {
     if (!internalSize) return
-    return cache.set(owner, { url, address: owner }, { ttl })
+    return cache.set(owner, { url, owner, ttl }, { ttl })
   }
 }

--- a/scheduler-utils/src/client/in-memory.js
+++ b/scheduler-utils/src/client/in-memory.js
@@ -1,14 +1,7 @@
 import { LRUCache } from 'lru-cache'
 
-/**
- * @type {LRUCache}
- */
-let internalCache
-let internalSize
 export function createLruCache ({ size }) {
-  if (internalCache) return internalCache
-  internalSize = size
-  internalCache = new LRUCache({
+  const cache = new LRUCache({
     /**
      * number of entries
      */
@@ -25,33 +18,45 @@ export function createLruCache ({ size }) {
     sizeCalculation: (v) => JSON.stringify(v).length,
     allowStale: true
   })
-  return internalCache
+  return cache
 }
 
-export function getByProcessWith ({ cache = internalCache }) {
+/**
+ * @param {{ cache: LRUCache }} params
+ */
+export function getByProcessWith ({ cache }) {
   return async (process) => {
-    if (!internalSize) return
+    if (!cache.max) return
     return cache.get(process)
   }
 }
 
-export function setByProcessWith ({ cache = internalCache }) {
+/**
+ * @param {{ cache: LRUCache }} params
+ */
+export function setByProcessWith ({ cache }) {
   return async (process, { url, address }, ttl) => {
-    if (!internalSize) return
+    if (!cache.max) return
     return cache.set(process, { url, address }, { ttl })
   }
 }
 
-export function getByOwnerWith ({ cache = internalCache }) {
+/**
+ * @param {{ cache: LRUCache }} params
+ */
+export function getByOwnerWith ({ cache }) {
   return async (owner) => {
-    if (!internalSize) return
+    if (!cache.max) return
     return cache.get(owner)
   }
 }
 
-export function setByOwnerWith ({ cache = internalCache }) {
+/**
+ * @param {{ cache: LRUCache }} params
+ */
+export function setByOwnerWith ({ cache }) {
   return async (owner, url, ttl) => {
-    if (!internalSize) return
-    return cache.set(owner, { url, owner, ttl }, { ttl })
+    if (!cache.max) return
+    return cache.set(owner, { url, address: owner }, { ttl })
   }
 }

--- a/scheduler-utils/src/locate.js
+++ b/scheduler-utils/src/locate.js
@@ -29,7 +29,13 @@ export function locateWith ({
            */
           if (schedulerHint) {
             const byOwner = await cache.getByOwner(schedulerHint)
-            if (byOwner) return byOwner
+            if (byOwner) {
+              return {
+                url: byOwner.url,
+                owner: byOwner.owner,
+                ttl: byOwner.ttl
+              }
+            }
 
             return loadScheduler(schedulerHint).then((scheduler) => {
               cache.setByOwner(scheduler.owner, scheduler.url, scheduler.ttl)
@@ -40,7 +46,6 @@ export function locateWith ({
           return loadProcessScheduler(process)
         })
         .then(async (scheduler) => {
-          console.log('scheduler', scheduler)
           let finalUrl = scheduler.url
           /**
            * If following redirects, then the initial request will be
@@ -49,10 +54,7 @@ export function locateWith ({
            */
           if (followRedirects) { finalUrl = await checkForRedirect(scheduler.url, process) }
 
-          const byProcess = {
-            url: finalUrl,
-            address: scheduler.owner
-          }
+          const byProcess = { url: finalUrl, address: scheduler.owner }
           await cache.setByProcess(process, byProcess, scheduler.ttl)
           return byProcess
         })

--- a/scheduler-utils/src/locate.js
+++ b/scheduler-utils/src/locate.js
@@ -1,4 +1,10 @@
-export function locateWith ({ loadProcessScheduler, loadScheduler, cache, followRedirects, checkForRedirect }) {
+export function locateWith ({
+  loadProcessScheduler,
+  loadScheduler,
+  cache,
+  followRedirects,
+  checkForRedirect
+}) {
   /**
    * Locate the scheduler for the given process.
    *
@@ -11,41 +17,44 @@ export function locateWith ({ loadProcessScheduler, loadScheduler, cache, follow
    * @returns {Promise<{ url: string, address: string }>} - an object whose url field is the Scheduler Location
    */
   return (process, schedulerHint) =>
-    cache.getByProcess(process)
-      .then(async (cached) => {
-        if (cached) return cached
+    cache.getByProcess(process).then(async (cached) => {
+      if (cached) return cached
 
-        return Promise.resolve()
-          .then(async () => {
-            /**
-             * The the scheduler hint was provided,
-             * so skip querying the process and instead
-             * query the Scheduler-Location record directly
-             */
-            if (schedulerHint) {
-              const byOwner = await cache.getByOwner(schedulerHint)
-              if (byOwner) return (byOwner)
+      return Promise.resolve()
+        .then(async () => {
+          /**
+           * The the scheduler hint was provided,
+           * so skip querying the process and instead
+           * query the Scheduler-Location record directly
+           */
+          if (schedulerHint) {
+            const byOwner = await cache.getByOwner(schedulerHint)
+            if (byOwner) return byOwner
 
-              return loadScheduler(schedulerHint).then((scheduler) => {
-                cache.setByOwner(scheduler.owner, scheduler.url, scheduler.ttl)
-                return scheduler
-              })
-            }
+            return loadScheduler(schedulerHint).then((scheduler) => {
+              cache.setByOwner(scheduler.owner, scheduler.url, scheduler.ttl)
+              return scheduler
+            })
+          }
 
-            return loadProcessScheduler(process)
-          })
-          .then(async (scheduler) => {
-            let finalUrl = scheduler.url
-            /**
-             * If following redirects, then the initial request will be
-             * to a router. So we go hit the router and cache the
-             * redirected url for performance.
-             */
-            if (followRedirects) finalUrl = await checkForRedirect(scheduler.url, process)
+          return loadProcessScheduler(process)
+        })
+        .then(async (scheduler) => {
+          console.log('scheduler', scheduler)
+          let finalUrl = scheduler.url
+          /**
+           * If following redirects, then the initial request will be
+           * to a router. So we go hit the router and cache the
+           * redirected url for performance.
+           */
+          if (followRedirects) { finalUrl = await checkForRedirect(scheduler.url, process) }
 
-            const byProcess = { url: finalUrl, address: scheduler.owner }
-            await cache.setByProcess(process, byProcess, scheduler.ttl)
-            return byProcess
-          })
-      })
+          const byProcess = {
+            url: finalUrl,
+            address: scheduler.owner
+          }
+          await cache.setByProcess(process, byProcess, scheduler.ttl)
+          return byProcess
+        })
+    })
 }

--- a/scheduler-utils/src/locate.test.js
+++ b/scheduler-utils/src/locate.test.js
@@ -16,7 +16,8 @@ describe('locateWith', () => {
         assert.equal(process, PROCESS)
         return { url: DOMAIN, ttl: TEN_MS, owner: SCHEDULER }
       },
-      loadScheduler: async () => assert.fail('should not load the scheduler if no hint'),
+      loadScheduler: async () =>
+        assert.fail('should not load the scheduler if no hint'),
       cache: {
         getByProcess: async (process) => {
           assert.equal(process, PROCESS)
@@ -37,8 +38,9 @@ describe('locateWith', () => {
       followRedirects: false
     })
 
-    await locate(PROCESS)
-      .then((res) => assert.deepStrictEqual(res, { url: DOMAIN, address: SCHEDULER }))
+    await locate(PROCESS).then((res) =>
+      assert.deepStrictEqual(res, { url: DOMAIN, address: SCHEDULER })
+    )
   })
 
   test('should serve the cached value', async () => {
@@ -46,20 +48,25 @@ describe('locateWith', () => {
       loadProcessScheduler: async () => {
         assert.fail('should never call on chain if in cache')
       },
-      loadScheduler: async () => assert.fail('should not load the scheduler if no hint'),
+      loadScheduler: async () =>
+        assert.fail('should not load the scheduler if no hint'),
       cache: {
         getByProcess: async (process) => {
           assert.equal(process, PROCESS)
           return { url: DOMAIN, address: SCHEDULER }
         },
-        getByOwner: async () => assert.fail('should not check cache by owner if cached by process'),
-        setByProcess: async () => assert.fail('should not set cache by process if cached by process'),
-        setByOwner: async () => assert.fail('should not set cache by owner if cached by process')
+        getByOwner: async () =>
+          assert.fail('should not check cache by owner if cached by process'),
+        setByProcess: async () =>
+          assert.fail('should not set cache by process if cached by process'),
+        setByOwner: async () =>
+          assert.fail('should not set cache by owner if cached by process')
       }
     })
 
-    await locate(PROCESS)
-      .then((res) => assert.deepStrictEqual(res, { url: DOMAIN, address: SCHEDULER }))
+    await locate(PROCESS).then((res) =>
+      assert.deepStrictEqual(res, { url: DOMAIN, address: SCHEDULER })
+    )
   })
 
   test('should load the redirected value and cache it', async () => {
@@ -68,7 +75,8 @@ describe('locateWith', () => {
         assert.equal(process, PROCESS)
         return { url: DOMAIN, ttl: TEN_MS, owner: SCHEDULER }
       },
-      loadScheduler: async () => assert.fail('should not load the scheduler if no hint'),
+      loadScheduler: async () =>
+        assert.fail('should not load the scheduler if no hint'),
       cache: {
         getByProcess: async (process) => {
           assert.equal(process, PROCESS)
@@ -97,13 +105,15 @@ describe('locateWith', () => {
       }
     })
 
-    await locate(PROCESS)
-      .then((res) => assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER }))
+    await locate(PROCESS).then((res) =>
+      assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER })
+    )
   })
 
   test('should use the scheduler hint and skip querying for the process', async () => {
     const locate = locateWith({
-      loadProcessScheduler: async () => assert.fail('should not load process if given a scheduler hint'),
+      loadProcessScheduler: async () =>
+        assert.fail('should not load process if given a scheduler hint'),
       loadScheduler: async (owner) => {
         assert.equal(owner, SCHEDULER)
         return { url: DOMAIN, ttl: TEN_MS, owner: SCHEDULER }
@@ -140,14 +150,17 @@ describe('locateWith', () => {
       }
     })
 
-    await locate(PROCESS, SCHEDULER)
-      .then((res) => assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER }))
+    await locate(PROCESS, SCHEDULER).then((res) =>
+      assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER })
+    )
   })
 
   test('should use the scheduler hint and use the cached owner', async () => {
     const locate = locateWith({
-      loadProcessScheduler: async () => assert.fail('should not load process if given a scheduler hint'),
-      loadScheduler: async () => assert.fail('should not load the scheduler if cached'),
+      loadProcessScheduler: async () =>
+        assert.fail('should not load process if given a scheduler hint'),
+      loadScheduler: async () =>
+        assert.fail('should not load the scheduler if cached'),
       cache: {
         getByProcess: async (process) => {
           assert.equal(process, PROCESS)
@@ -163,7 +176,8 @@ describe('locateWith', () => {
           assert.equal(address, SCHEDULER)
           assert.equal(ttl, TEN_MS)
         },
-        setByOwner: async () => assert.fail('should not cache by owner if cached')
+        setByOwner: async () =>
+          assert.fail('should not cache by owner if cached')
       },
       followRedirects: true,
       checkForRedirect: async (url, process) => {
@@ -173,7 +187,8 @@ describe('locateWith', () => {
       }
     })
 
-    await locate(PROCESS, SCHEDULER)
-      .then((res) => assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER }))
+    await locate(PROCESS, SCHEDULER).then((res) =>
+      assert.deepStrictEqual(res, { url: DOMAIN_REDIRECT, address: SCHEDULER })
+    )
   })
 })


### PR DESCRIPTION
The section for schedulerHint in the locateWith function has a different schema than the downstream code is expecting. That object's schema has been changed to { url, owner, ttl }, in both the locate.js and in-memory.js files. Code related to getByProcess and setByProcess remains the same { url, address }.

Tests within scheduler-utils project are all passing:
<img width="819" alt="Screenshot 2024-04-10 at 12 33 32 PM" src="https://github.com/permaweb/ao/assets/1474935/2f16160d-c16a-4060-b23a-50222a5c9b0b">
