### PR TITLE
feat(cu): dedupe duplicate assignments and duplicate pushes

### DIFF
--- a/servers/cu/src/domain/client/ao-process.js
+++ b/servers/cu/src/domain/client/ao-process.js
@@ -203,7 +203,7 @@ export function saveProcessWith ({ db }) {
       sql: `
         INSERT OR IGNORE INTO ${PROCESSES_TABLE}
         (id, signature, data, anchor, owner, tags, block)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?);
       `,
       parameters: [
         process.id,

--- a/servers/cu/src/domain/dal.js
+++ b/servers/cu/src/domain/dal.js
@@ -72,7 +72,7 @@ export const findEvaluationSchema = z.function()
   .returns(z.promise(evaluationSchema))
 
 export const saveEvaluationSchema = z.function()
-  .args(evaluationSchema.extend({ deepHash: z.string().nullish() }))
+  .args(evaluationSchema.extend({ deepHash: z.string().nullish(), isAssignment: z.boolean() }))
   .returns(z.promise(z.any()))
 
 export const findEvaluationsSchema = z.function()
@@ -94,6 +94,27 @@ export const findEvaluationsSchema = z.function()
   }))
   .returns(z.promise(z.array(evaluationSchema)))
 
+// Messages
+
+export const findMessageBeforeSchema = z.function()
+  .args(z.object({
+    messageId: z.string().nullish(),
+    deepHash: z.string().nullish(),
+    isAssignment: z.boolean(),
+    processId: z.string(),
+    epoch: z.coerce.number(),
+    nonce: z.coerce.number()
+  }))
+  /**
+   * Our business logic doesn't use the output,
+   * only the presence or absence of the record,
+   *
+   * So we don't need to enforce a shape to return here
+   */
+  .returns(z.promise(z.any()))
+
+// Blocks
+
 export const saveBlocksSchema = z.function()
   .args(z.array(blockSchema))
   .returns(z.promise(z.any()))
@@ -104,22 +125,6 @@ export const findBlocksSchema = z.function()
     maxTimestamp: z.number()
   }))
   .returns(z.promise(z.array(blockSchema)))
-
-export const findMessageHashBeforeSchema = z.function()
-  .args(z.object({
-    messageHash: z.string().nullish(),
-    processId: z.string(),
-    timestamp: z.coerce.number(),
-    ordinate: z.coerce.string()
-  }))
-  /**
-   * Our business logic doesn't use the output of findMessageHash,
-   * only the presence or absence of the document,
-   *
-   * So we don't need to enforce a shape to return here,
-   * as long as it's a document (an object)
-   */
-  .returns(z.promise(z.any()))
 
 // SU
 

--- a/servers/cu/src/domain/index.js
+++ b/servers/cu/src/domain/index.js
@@ -56,7 +56,7 @@ export const createApis = async (ctx) => {
     cacheKeyFn: ({ processId }) => processId
   })
 
-  const sqlite = await SqliteClient.createSqliteClient({ url: `${ctx.DB_URL}.sqlite` })
+  const sqlite = await SqliteClient.createSqliteClient({ url: `${ctx.DB_URL}.sqlite`, bootstrap: true })
 
   const workerPool = workerpool.pool(join(__dirname, 'client', 'worker.js'), {
     maxWorkers: ctx.WASM_EVALUATION_MAX_WORKERS,

--- a/servers/cu/src/domain/index.js
+++ b/servers/cu/src/domain/index.js
@@ -194,7 +194,7 @@ export const createApis = async (ctx) => {
       evaluate: (...args) => workerPool.exec('evaluate', args),
       logger
     }),
-    findMessageHashBefore: AoEvaluationClient.findMessageHashBeforeWith({ db: sqlite, logger }),
+    findMessageBefore: AoEvaluationClient.findMessageBeforeWith({ db: sqlite, logger }),
     loadTimestamp: AoSuClient.loadTimestampWith({ fetch: ctx.fetch, logger }),
     loadProcess: AoSuClient.loadProcessWith({ fetch: ctx.fetch, logger }),
     loadMessages: AoSuClient.loadMessagesWith({ fetch: ctx.fetch, pageSize: 1000, logger }),


### PR DESCRIPTION
Needed as part of `aop1` to deduplicate assignments and pushed messages.

`messages` is a separate table which will make hydration from a `Checkpoint`, disregarding evluations, simpler