### PR TITLE
fix(connect): add missing limit arg to results api

### DIFF
--- a/connect/src/client/ao-cu.js
+++ b/connect/src/client/ao-cu.js
@@ -80,6 +80,7 @@ export function loadResultWith ({ fetch, CU_URL, logger }) {
  * @property {string} from - cursor to start the list of results
  * @property {string} to - cursor to stop the list of results
  * @property {string} sort - "ASC" or "DESC" to describe the order of list
+ * @property {number} limit - the number of results to return
  *
  * @callback QueryResults
  * @param {QueryResultsArgs} args

--- a/connect/src/dal.js
+++ b/connect/src/dal.js
@@ -31,7 +31,7 @@ export const queryResultsSchema = z.function()
     from: z.string().optional(),
     to: z.string().optional(),
     sort: z.enum(['ASC', 'DESC']).default('ASC'),
-    limit: z.string().optional()
+    limit: z.number().optional()
   }))
   .returns(z.promise(z.object({
     edges: z.array(z.object({

--- a/connect/src/lib/results/index.js
+++ b/connect/src/lib/results/index.js
@@ -40,8 +40,8 @@ export function resultsWith (env) {
   const verifyInput = verifyInputWith(env)
   const query = queryWith(env)
 
-  return ({ process, from, to, sort }) => {
-    return of({ process, from, to, sort })
+  return ({ process, from, to, sort, limit }) => {
+    return of({ process, from, to, sort, limit })
       .chain(verifyInput)
       .chain(query)
       .map(

--- a/connect/src/lib/results/query.js
+++ b/connect/src/lib/results/query.js
@@ -20,7 +20,7 @@ export function queryWith ({ queryResults }) {
   queryResults = fromPromise(queryResultsSchema.implement(queryResults))
 
   return (ctx) => {
-    return of({ process: ctx.process, from: ctx.from, to: ctx.to, sort: ctx.sort })
+    return of({ process: ctx.process, from: ctx.from, to: ctx.to, sort: ctx.sort, limit: ctx.limit })
       .chain(queryResults)
   }
 }

--- a/connect/src/lib/results/query.test.js
+++ b/connect/src/lib/results/query.test.js
@@ -11,7 +11,8 @@ describe('query', () => {
           process: 'process-123',
           from: '1',
           to: '2',
-          sort: 'DESC'
+          sort: 'DESC',
+          limit: 1
         })
 
         return {
@@ -33,7 +34,8 @@ describe('query', () => {
       process: 'process-123',
       from: '1',
       to: '2',
-      sort: 'DESC'
+      sort: 'DESC',
+      limit: 1
     }).toPromise()
 
     assert.deepStrictEqual(res, {

--- a/connect/src/lib/results/verify-input.js
+++ b/connect/src/lib/results/verify-input.js
@@ -6,7 +6,7 @@ const inputSchema = z.object({
   from: z.string().optional(),
   to: z.string().optional(),
   sort: z.enum(['ASC', 'DESC']).default('ASC'),
-  limit: z.string().optional()
+  limit: z.number().optional()
 })
 
 /**

--- a/connect/src/lib/results/verify-input.test.js
+++ b/connect/src/lib/results/verify-input.test.js
@@ -10,12 +10,14 @@ describe('verify-input', () => {
     await verifyInput({
       process: 'process-123',
       from: '1',
-      to: '2'
+      to: '2',
+      limit: 1
     }).toPromise()
       .then(res => assert.deepStrictEqual(res, {
         process: 'process-123',
         from: '1',
-        to: '2'
+        to: '2',
+        limit: 1
       }))
   })
 


### PR DESCRIPTION
The docs + the ao-cu implementation talk about/use a `limit` property which was missing from the results api.
The zod object also had a property `limit`, although it was marked as a string. I've changed this to be a number.