### PR TITLE
fix(mu): docker image fails on missing directory for `postinstall` co…

### DIFF
--- a/servers/mu/Dockerfile
+++ b/servers/mu/Dockerfile
@@ -8,6 +8,7 @@ COPY ./package.json .
 COPY ./package-lock.json .
 COPY ./src ./src
 COPY ./entrypoint.sh ./entrypoint.sh
+COPY ./cranker ./cranker
 
 RUN chmod +x /usr/app/entrypoint.sh
 


### PR DESCRIPTION
…mmand

Fixes docker build issue with `mu`

```bash
❯ docker build . -t ao-mu
[+] Building 115.9s (14/14) FINISHED                                                                                                                                                                                                                                                                                                                                           docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                                           0.0s
 => => transferring dockerfile: 372B                                                                                                                                                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/node:21                                                                                                                                                                                                                                                                                                                                     1.5s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                                                                                                                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                              0.0s
 => => transferring context: 67B                                                                                                                                                                                                                                                                                                                                                               0.0s
 => [1/9] FROM docker.io/library/node:21@sha256:bda531283f4bafd1cb41294493de89ae3c4cf55933da14710e46df970e77365e                                                                                                                                                                                                                                                                              91.6s
 => => resolve docker.io/library/node:21@sha256:bda531283f4bafd1cb41294493de89ae3c4cf55933da14710e46df970e77365e                                                                                                                                                                                                                                                                               0.0s
 => => sha256:fcf2fd38c348a90e4a0c762b4ca31e3c997fd081cdeb328a07aeb56a25083153 2.00kB / 2.00kB                                                                                                                                                                                                                                                                                                 0.0s
 => => sha256:2cf9c2b42f41b1845f3e4421b723d56146db82939dc884555e077768e18132f4 24.05MB / 24.05MB                                                                                                                                                                                                                                                                                              15.1s
 => => sha256:bda531283f4bafd1cb41294493de89ae3c4cf55933da14710e46df970e77365e 1.21kB / 1.21kB                                                                                                                                                                                                                                                                                                 0.0s
 => => sha256:9ed275c850471e0001d4ad56967891bfa0640e0c7631297f07ca78f885716a32 7.41kB / 7.41kB                                                                                                                                                                                                                                                                                                 0.0s
 => => sha256:1468e7ff95fcb865fbc4dee7094f8b99c4dcddd6eb2180cf044c7396baf6fc2f 49.58MB / 49.58MB                                                                                                                                                                                                                                                                                              27.7s
 => => sha256:c4c40c3e3cdf945721f480e1d939aac857876fdb5c33b8fbfcf655c63b0b9428 64.14MB / 64.14MB                                                                                                                                                                                                                                                                                              32.9s
 => => sha256:c05cc1123d7e335d59b0f465c23b7ad2ad27f4875b6c3eab41c65a9b50efa382 211.18MB / 211.18MB                                                                                                                                                                                                                                                                                            76.7s
 => => extracting sha256:1468e7ff95fcb865fbc4dee7094f8b99c4dcddd6eb2180cf044c7396baf6fc2f                                                                                                                                                                                                                                                                                                      3.5s
 => => sha256:04f2356c02d21ef160986f7994210be28dab889b9ba0724e126bd2ee4ed21cd6 3.37kB / 3.37kB                                                                                                                                                                                                                                                                                                28.2s
 => => sha256:fd0103e43e6527c2b5205fe066f191b582a9b7af7133b88fab58f74d76cd40f3 49.72MB / 49.72MB                                                                                                                                                                                                                                                                                              50.4s
 => => extracting sha256:2cf9c2b42f41b1845f3e4421b723d56146db82939dc884555e077768e18132f4                                                                                                                                                                                                                                                                                                      0.9s
 => => extracting sha256:c4c40c3e3cdf945721f480e1d939aac857876fdb5c33b8fbfcf655c63b0b9428                                                                                                                                                                                                                                                                                                      4.1s
 => => sha256:8a7c6202e2f94258e03324267952ce88cc336ebdb8b7c24e84fa36ebd8b1c2db 1.25MB / 1.25MB                                                                                                                                                                                                                                                                                                33.8s
 => => sha256:82cce69906c7095c867d97123b970da23bc5a5027f7068e1bc6b15dc24865b7f 452B / 452B                                                                                                                                                                                                                                                                                                    34.0s
 => => extracting sha256:c05cc1123d7e335d59b0f465c23b7ad2ad27f4875b6c3eab41c65a9b50efa382                                                                                                                                                                                                                                                                                                     10.4s
 => => extracting sha256:04f2356c02d21ef160986f7994210be28dab889b9ba0724e126bd2ee4ed21cd6                                                                                                                                                                                                                                                                                                      0.0s
 => => extracting sha256:fd0103e43e6527c2b5205fe066f191b582a9b7af7133b88fab58f74d76cd40f3                                                                                                                                                                                                                                                                                                      3.6s
 => => extracting sha256:8a7c6202e2f94258e03324267952ce88cc336ebdb8b7c24e84fa36ebd8b1c2db                                                                                                                                                                                                                                                                                                      0.1s
 => => extracting sha256:82cce69906c7095c867d97123b970da23bc5a5027f7068e1bc6b15dc24865b7f                                                                                                                                                                                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                                              0.0s
 => => transferring context: 192.34kB                                                                                                                                                                                                                                                                                                                                                          0.0s
 => [2/9] RUN apt update && apt install -y bash git awscli                                                                                                                                                                                                                                                                                                                                    14.9s
 => [3/9] WORKDIR /usr/app                                                                                                                                                                                                                                                                                                                                                                     0.0s 
 => [4/9] COPY ./package.json .                                                                                                                                                                                                                                                                                                                                                                0.0s 
 => [5/9] COPY ./package-lock.json .                                                                                                                                                                                                                                                                                                                                                           0.0s
 => [6/9] COPY ./src ./src                                                                                                                                                                                                                                                                                                                                                                     0.0s
 => [7/9] COPY ./entrypoint.sh ./entrypoint.sh                                                                                                                                                                                                                                                                                                                                                 0.0s
 => [8/9] RUN chmod +x /usr/app/entrypoint.sh                                                                                                                                                                                                                                                                                                                                                  0.2s
 => ERROR [9/9] RUN npm install --ignore-engines                                                                                                                                                                                                                                                                                                                                               7.5s
------
 > [9/9] RUN npm install --ignore-engines:
0.714 npm WARN EBADENGINE Unsupported engine {
0.714 npm WARN EBADENGINE   package: '@permaweb/ao-mu@1.0.0',
0.715 npm WARN EBADENGINE   required: { node: '18' },
0.715 npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
0.715 npm WARN EBADENGINE }
7.405 
7.405 > @permaweb/ao-mu@1.0.0 postinstall
7.405 > cd cranker && npm install
7.405 
7.409 sh: 1: cd: can't cd to cranker
7.410 npm notice 
7.410 npm notice New minor version of npm available! 10.5.0 -> 10.6.0
7.410 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.6.0>
7.410 npm notice Run `npm install -g npm@10.6.0` to update!
7.410 npm notice 
7.412 npm ERR! code 2
7.412 npm ERR! path /usr/app
7.413 npm ERR! command failed
7.413 npm ERR! command sh -c cd cranker && npm install
7.415 
7.415 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2024-04-29T17_17_31_968Z-debug-0.log
------
Dockerfile:14
--------------------
  12 |     RUN chmod +x /usr/app/entrypoint.sh
  13 |     
  14 | >>> RUN npm install --ignore-engines
  15 |     
  16 |     ENV NODE_ENV=production
--------------------
ERROR: failed to solve: process "/bin/sh -c npm install --ignore-engines" did not complete successfully: exit code: 2
```