### PR TITLE
feat(cu): dry-run only uses latest memory for process to perform dry-run evals #674

### DIFF
--- a/servers/cu/src/domain/api/dryRun.js
+++ b/servers/cu/src/domain/api/dryRun.js
@@ -1,162 +1,115 @@
 import { Readable } from 'node:stream'
 import { omit } from 'ramda'
-import { Resolved, of } from 'hyper-async'
+import { of } from 'hyper-async'
 
-import { loadMessageMetaWith } from '../lib/loadMessageMeta.js'
+import { loadProcessWith } from '../lib/loadProcess.js'
+import { loadModuleWith } from '../lib/loadModule.js'
 import { evaluateWith } from '../lib/evaluate.js'
 import { messageSchema } from '../model.js'
-import { loadModuleWith } from '../lib/loadModule.js'
 import { mapFrom } from '../utils.js'
-import { readStateWith } from './readState.js'
 
 /**
  * @typedef Env
  *
  * @typedef Result
  *
- * @typedef ReadResultArgs
- * @property {string} messageTxId
+ * @typedef DryRunArgs
+ * @property {string} processId
+ * @property {any} dryRun
  *
- * @callback ReadResult
- * @param {ReadResultArgs} args
+ * @callback DryRun
+ * @param {DryRunArgs} args
  * @returns {Promise<Result>} result
  *
  * @param {Env} - the environment
- * @returns {ReadResult}
+ * @returns {DryRun}
  */
 export function dryRunWith (env) {
-  const loadMessageMeta = loadMessageMetaWith(env)
+  const loadProcess = loadProcessWith(env)
   const loadModule = loadModuleWith(env)
-  const readState = readStateWith(env)
   const evaluate = evaluateWith(env)
 
-  return ({ processId, messageTxId, dryRun }) => {
-    return of({ messageTxId })
-      .chain(({ messageTxId }) => {
-        /**
-         * Load the metadata associated with the messageId ie.
-         * it's timestamp and ordinate, so readState can evaluate
-         * up to that point (if it hasn't already)
-         */
-        if (messageTxId) return loadMessageMeta({ processId, messageTxId })
+  return ({ processId, dryRun }) => {
+    const stats = {
+      startTime: new Date(),
+      endTime: undefined,
+      messages: {
+        scheduled: 0,
+        cron: 0
+      }
+    }
 
-        /**
-         * No messageTxId provided so evaluate up to latest
-         */
-        return Resolved({
-          processId,
-          to: undefined,
-          ordinate: undefined
-        })
-      })
-      /**
-       * Read up to the specified 'to', or latest
-       */
-      .chain((res) =>
-        readState({
-          processId: res.processId,
-          to: res.timestamp,
-          /**
-           * The ordinate for a scheduled message is it's nonce
-           */
-          ordinate: res.nonce && `${res.nonce}`,
-          /**
-           * We know this is a scheduled message, and so has no
-           * associated cron.
-           *
-           * So we explicitly set cron to undefined, for posterity
-           */
-          cron: undefined,
-          /**
-           * If we are evaluating up to a specific message, as indicated by
-           * the presence of messageTxId, then we make sure we get an exact match.
-           *
-           * Otherwise, we are evaluating up to the latest
-           */
-          exact: !!messageTxId,
-          needsMemory: true
-        })
+    const logStats = (res) => {
+      stats.endTime = new Date()
+      env.logger(
+        'dryRun for process "%s" at nonce "%s" took %d milliseconds: %j',
+        processId,
+        res.ordinate,
+        stats.endTime - stats.startTime,
+        stats
       )
-      /**
-       * We've read up to 'to', now inject the dry-run message
-       *
-       * { id, owner, tags, output: { Memory, Error, Messages, Spawns, Output } }
-       */
-      .chain((readStateRes) => {
-        return of(readStateRes)
-          .chain((ctx) => {
-            /**
-             * If a cached evaluation was found and immediately returned,
-             * then we will have not loaded the module and attached it to ctx.
-             *
-             * So we check if ctx.module is set, and load the Module if not.
-             *
-             * This check will prevent us from unnecessarily loading the module
-             * from Arweave, twice.
-             */
-            if (!ctx.moduleId) return loadModule(ctx)
 
+      return res
+    }
+
+    return of({ id: processId, stats })
+      .chain(loadProcess)
+      .chain(loadModule)
+      .chain((ctx) => {
+        async function * dryRunMessage () {
+          /**
+           * Dry run messages are not signed, and therefore
+           * will not have a verifiable Id, Signature, Owner, etc.
+           *
+           * NOTE:
+           * Dry Run messages are not signed, therefore not verifiable.
+           *
+           * This is generally okay, because dry-run message evaluations
+           * are Read-Only and not persisted -- the primary use-case for Dry Run is to enable
+           * retrieving a view of a processes state, without having to send a bonafide message.
+           *
+           * However, we should keep in mind the implications. One implication is that spoofing
+           * Owner or other fields on a Dry-Run message (unverifiable context) exposes a way to
+           * "poke and prod" a process modules for vulnerabilities.
+           */
+          yield messageSchema.parse({
             /**
-             * The module was loaded by readState, as part of evaluation,
-             * so no need to load it again. Just reuse it
+             * Don't save the dryRun message
              */
-            return Resolved(ctx)
-          })
-          .chain((ctx) => {
-            async function * dryRunMessage () {
+            noSave: true,
+            deepHash: undefined,
+            cron: undefined,
+            ordinate: ctx.ordinate,
+            name: 'Dry Run Message',
+            message: {
               /**
-               * Dry run messages are not signed, and therefore
-               * will not have a verifiable Id, Signature, Owner, etc.
+               * We default timestamp and block-height using
+               * the current evaluation.
                *
-               * NOTE:
-               * Dry Run messages are not signed, therefore not verifiable.
-               *
-               * This is generally okay, because dry-run message evaluations
-               * are Read-Only and not persisted -- the primary use-case for Dry Run is to enable
-               * retrieving a view of a processes state, without having to send a bonafide message.
-               *
-               * However, we should keep in mind the implications. One implication is that spoofing
-               * Owner or other fields on a Dry-Run message (unverifiable context) exposes a way to
-               * "poke and prod" a process modules for vulnerabilities.
+               * The Dry-Run message can overwrite them
                */
-              yield messageSchema.parse({
-                /**
-                 * Don't save the dryRun message
-                 */
-                noSave: true,
-                deepHash: undefined,
-                cron: undefined,
-                ordinate: ctx.ordinate,
-                name: 'Dry Run Message',
-                message: {
-                  /**
-                   * We default timestamp and block-height using
-                   * the current evaluation.
-                   *
-                   * The Dry-Run message can overwrite them
-                   */
-                  Timestamp: ctx.from,
-                  'Block-Height': ctx.fromBlockHeight,
-                  Cron: false,
-                  Target: processId,
-                  ...dryRun,
-                  From: mapFrom({ tags: dryRun.Tags, owner: dryRun.Owner }),
-                  'Read-Only': true
-                },
-                AoGlobal: {
-                  Process: { Id: processId, Owner: ctx.owner, Tags: ctx.tags },
-                  Module: { Id: ctx.moduleId, Owner: ctx.moduleOwner, Tags: ctx.moduleTags }
-                }
-              })
+              Timestamp: ctx.from,
+              'Block-Height': ctx.fromBlockHeight,
+              Cron: false,
+              Target: processId,
+              ...dryRun,
+              From: mapFrom({ tags: dryRun.Tags, owner: dryRun.Owner }),
+              'Read-Only': true
+            },
+            AoGlobal: {
+              Process: { Id: processId, Owner: ctx.owner, Tags: ctx.tags },
+              Module: { Id: ctx.moduleId, Owner: ctx.moduleOwner, Tags: ctx.moduleTags }
             }
-
-            /**
-             * Pass a messages stream to evaluate that only emits the single dry-run
-             * message and then completes
-             */
-            return evaluate({ ...ctx, messages: Readable.from(dryRunMessage()) })
           })
+        }
+
+        /**
+         * Pass a messages stream to evaluate that only emits the single dry-run
+         * message and then completes
+         */
+        return evaluate({ ...ctx, messages: Readable.from(dryRunMessage()) })
       })
+      .bimap(logStats, logStats)
       .map((res) => res.output)
       .map(omit(['Memory']))
   }


### PR DESCRIPTION
Closes #674 

`readState` is no longer invoked by `dryRun`. Instead `dryRun` simply loads the process (which includes caching process, loading it's latest memory, and priming the LRU In-Memory cache if needed), loads the module (which includes caching),
then finally evaluates the single dryRun message