### PR TITLE
fix(ur): do not parse body on root mu POST route, if request is an assignment #697

### DIFF
--- a/servers/ur/src/routes/mu.js
+++ b/servers/ur/src/routes/mu.js
@@ -27,33 +27,55 @@ export function mountMuRoutesWith ({ app, middleware }) {
     return middleware({ processIdFromRequest: () => 'process' })(req, res, next)
   })
 
-  /**
-   * Since the MU receives opaque data items, we have to unpack it, to know which MU
-   * to route to
-   */
-  app.post('/', express.raw({ type: 'application/octet-stream', limit: '10mb' }), middleware({
-    processIdFromRequest: async (req) => {
-      const dataItem = new DataItem(Buffer.from(req.body))
+  app.post('/',
+    (req, res, next) => {
+      if (req.query.assign) {
+        /**
+         * This flag is used in subsequent steps to branch
+         * (see below)
+         */
+        req.isAssignment = true
+        return next()
+      }
 
-      if (!(await dataItem.isValid())) throw new InvalidDataItemError('A valid and signed data item must be provided as the body')
-      /**
-       * The processId is the target on a message data item
-       */
-      if (isMessage(dataItem)) return dataItem.target
-      /**
-       * The processId is the dataItem itself on a process data item
-       */
-      if (isProcess(dataItem)) return dataItem.id
-
-      throw new InvalidDataItemError('Could not determine ao type of DataItem based on tag \'Type\'')
+      return express.raw({ type: 'application/octet-stream', limit: '10mb' })(req, res, next)
     },
-    /**
-     * Since we consumed the request stream in order to parse the data item and
-     * determine the processId, we must provide a new request stream, to be sent
-     * as the body on proxied request
-     */
-    restreamBody: (req) => Readable.from(req.body)
-  }))
+    middleware({
+      processIdFromRequest: async (req) => {
+        /**
+         * This request is an assignment, so there is no reason
+         * to consume the body in order to extract the processId
+         *
+         * as it is instead available as query parameter
+         */
+        if (req.isAssignment) return req.query['process-id']
+
+        /**
+         * Since the MU receives opaque data items, the only place to extract the process id is
+         * the data item itself. So we first parse and validate the data item, then extract the process id
+         * based on the data item type.
+         */
+        const dataItem = new DataItem(Buffer.from(req.body))
+
+        if (!(await dataItem.isValid())) throw new InvalidDataItemError('A valid and signed data item must be provided as the body')
+        /**
+         * The processId is the target on a message data item
+         */
+        if (isMessage(dataItem)) return dataItem.target
+        /**
+         * The processId is the dataItem itself on a process data item
+         */
+        if (isProcess(dataItem)) return dataItem.id
+
+        throw new InvalidDataItemError('Could not determine ao type of DataItem based on tag \'Type\'')
+      },
+      /**
+       * Since we consumed the request stream in order to parse the data item and
+       * determine the processId, we must provide a new request stream, to be sent
+       * as the body on proxied request
+       */
+      restreamBody: (req) => Readable.from(req.body)
+    }))
 
   app.post('/monitor/:processId', middleware({ processIdFromRequest: (req) => req.params.processId }))
   app.delete('/monitor/:processId', middleware({ processIdFromRequest: (req) => req.params.processId }))


### PR DESCRIPTION
This PR makes it so that the MU route will conditionally consume the body based on whether or not the `assign` query parameter is provided. In this case, there is no body to consume. Additionally, the `processId` is available as a `process-id` query parameter, and so can be extracted from there.