### PR TITLE
fix(cu): ensure thrown error in backoff will always be encapsulated by promise chain #729

### DIFF
--- a/servers/cu/src/domain/utils.js
+++ b/servers/cu/src/domain/utils.js
@@ -379,18 +379,18 @@ export const backoff = (
         // Reached max number of retries
         if (retry >= maxRetries) {
           log(`(${name}) Reached max number of retries: ${maxRetries}. Bubbling err`)
-          throw err
+          return Promise.reject(err)
         }
 
         const newRetry = retry + 1
         const newDelay = delay + delay
         log(`(${name}) Backing off -- retry ${newRetry} starting in ${newDelay} milliseconds...`)
-        return new Promise((resolve) =>
+        return new Promise((resolve, reject) =>
           setTimeout(
           /**
            * increment the retry count Retry with an exponential backoff
            */
-            () => resolve(action(newRetry, newDelay)),
+            () => action(newRetry, newDelay).then(resolve).catch(reject),
             /**
              * Retry in {delay} milliseconds
              */


### PR DESCRIPTION
Closes #729 