### PR TITLE
fix(mu): handle duplicate from-process tags on transactions #660

### DIFF
--- a/servers/mu/src/domain/lib/build-tx.test.js
+++ b/servers/mu/src/domain/lib/build-tx.test.js
@@ -18,6 +18,9 @@ async function buildAndSign ({ processId, tags, anchor }) {
   assert.equal(tags.find((tag) =>
     tag.name === 'From-Process'
   ).value, 'process-123')
+  assert.equal(tags.filter((tag) =>
+    tag.name === 'From-Process'
+  ).length, 1)
 
   return {
     id: 'id-1',
@@ -54,6 +57,35 @@ describe('buildTx', () => {
           Target: 'id-1',
           Tags: [
             { name: 'Assignments', value: ['p1', 'p2'] }
+          ],
+          Anchor: 'anchor-1',
+          Data: 'data-1'
+        },
+        fromProcessId: 'process-123'
+      }
+    }).toPromise()
+
+    assert.equal(result.tx.processId, 'id-1')
+    assert.deepStrictEqual(result.tagAssignments, [{ Processes: ['p1', 'p2'], Message: 'id-1' }])
+  })
+
+  test('build and sign a tx from a cached msg with duplicate tags', async () => {
+    const buildTx = buildTxWith({
+      buildAndSign,
+      logger,
+      locateProcess,
+      fetchSchedulerProcess,
+      isWallet
+    })
+
+    const result = await buildTx({
+      cachedMsg: {
+        msg: {
+          Target: 'id-1',
+          Tags: [
+            { name: 'Assignments', value: ['p1', 'p2'] },
+            { name: 'From-Process', value: 'Process1' },
+            { name: 'From-Process', value: 'Process2' }
           ],
           Anchor: 'anchor-1',
           Data: 'data-1'


### PR DESCRIPTION
Closes #660 
MU is filtering out duplicates, but they are generated in ao-connect by users. Decided to be nonissue, but test added to ensure duplicate From-Process tags are outputted as one tag.