### PR TITLE
perf(su): alter message table index for faster reads

### DIFF
--- a/servers/su/migrations/2024-05-29-143054_messages_indexing/down.sql
+++ b/servers/su/migrations/2024-05-29-143054_messages_indexing/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+CREATE INDEX idx_messages_process_id ON messages(process_id);
+DROP INDEX idx_messages_process_id_timestamp;

--- a/servers/su/migrations/2024-05-29-143054_messages_indexing/up.sql
+++ b/servers/su/migrations/2024-05-29-143054_messages_indexing/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+DROP INDEX idx_messages_process_id;
+CREATE INDEX idx_messages_process_id_timestamp ON messages(process_id, timestamp);


### PR DESCRIPTION
Adds migrations to remove the previous index for process_id and adds a new index combining process_id and timestamp. This speeds up queries to retrieve messages significantly.