### PR TITLE
fix(mu): change try catch to .catch in mu worker

### DIFF
--- a/servers/mu/src/domain/clients/worker.js
+++ b/servers/mu/src/domain/clients/worker.js
@@ -115,12 +115,10 @@ function processResultsWith ({ dequeue, processResult, logger }) {
       const result = dequeue()
       if (result) {
         logger(`Processing task of type ${result.type}`)
-        try {
-          processResult(result)
-        } catch (e) {
+        processResult(result).catch((e) => {
           logger(`Result failed with error ${e}, will not recover`)
           logger(e)
-        }
+        })
       } else {
         await new Promise(resolve => setTimeout(resolve, 100))
       }


### PR DESCRIPTION
References #661, #743

Fixes try catch block in MU worker. Needs to be a .catch since work happening asynchronously 