### PR TITLE
feat(loader): weavedrive should be optional for wasm64

### DIFF
--- a/loader/src/formats/wasm64-emscripten.cjs
+++ b/loader/src/formats/wasm64-emscripten.cjs
@@ -670,6 +670,9 @@ var Module = (() => {
       function __asyncjs__weavedrive_open(c_filename, mode) {
         return Asyncify.handleAsync(async () => {
           const filename = UTF8ToString(Number(c_filename));
+          if (!Module.WeaveDrive) {
+            return Promise.resolve(null);
+          }
           const drive = Module.WeaveDrive(Module, FS);
           return await drive.open(filename);
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "markdown-toc-gen": "^1.0.1",
         "sort-package-json": "^2.10.0",
         "standard": "^17.1.0"
+      },
+      "engines": {
+        "yarn": "please-use-npm"
       }
     },
     "loader": {


### PR DESCRIPTION
Updated the wasm64 format to make weavedrive optional