### PR TITLE
chore(cu): bump deps

### DIFF
--- a/servers/cu/package-lock.json
+++ b/servers/cu/package-lock.json
@@ -13,11 +13,11 @@
         "@permaweb/ao-scheduler-utils": "^0.0.19",
         "arweave": "^1.15.1",
         "async-lock": "^1.4.1",
-        "better-sqlite3": "^9.6.0",
+        "better-sqlite3": "^11.0.0",
         "bytes": "^3.1.2",
         "cors": "^2.8.5",
         "dataloader": "^2.2.2",
-        "debug": "^4.3.4",
+        "debug": "^4.3.5",
         "dotenv": "^16.4.5",
         "fast-glob": "^3.3.2",
         "fastify": "^4.27.0",
@@ -27,13 +27,13 @@
         "ms": "^2.1.3",
         "p-map": "^7.0.2",
         "prom-client": "^15.1.2",
-        "ramda": "^0.30.0",
+        "ramda": "^0.30.1",
         "warp-arbundles": "^1.0.4",
-        "workerpool": "^9.1.1",
-        "zod": "^3.23.7"
+        "workerpool": "^9.1.2",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
-        "nodemon": "^3.1.0"
+        "nodemon": "^3.1.3"
       },
       "engines": {
         "node": ">=18",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.0.0.tgz",
+      "integrity": "sha512-1NnNhmT3EZTsKtofJlMox1jkMxdedILury74PwUbQBjWgo4tL4kf7uTAjU55mgQwjdzqakSTjkf+E1imrFwjnA==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
@@ -501,9 +501,9 @@
       "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
-      "integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.3.tgz",
+      "integrity": "sha512-m4Vqs+APdKzDFpuaL9F9EVOF85+h070FnkHVEoU4+rmT6Vw0bmNl7s61VEkY/cJkL7RCv1p4urnUDUMrS5rk2w==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -1242,9 +1242,9 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/ramda": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.0.tgz",
-      "integrity": "sha512-13Y0iMhIQuAm/wNGBL/9HEqIfRGmNmjKnTPlKWfA9f7dnDkr8d45wQ+S7+ZLh/Pq9PdcGxkqKUEA7ySu1QSd9Q==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
+      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -1753,9 +1753,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.1.tgz",
-      "integrity": "sha512-EFoFTSEo9m4V4wNrwzVRjxnf/E/oBpOzcI/R5CIugJhl9RsCiq525rszo4AtqcjQQoqFdu2E3H82AnbtpaQHvg=="
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.2.tgz",
+      "integrity": "sha512-5wZwyy5lcqrakQQcjaYQgVCbMR3djwIFWXuD2EGk/o/9bL3bd2kRGNwF74Bhcf1CIkAIwoOMG82EVnA5JmVVNw=="
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -1768,9 +1768,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/zod": {
-      "version": "3.23.7",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.7.tgz",
-      "integrity": "sha512-NBeIoqbtOiUMomACV/y+V3Qfs9+Okr18vR5c/5pHClPpufWOrsx8TENboDPe265lFdfewX2yBtNTLPvnmCxwog==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1995,9 +1995,9 @@
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "better-sqlite3": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.0.0.tgz",
+      "integrity": "sha512-1NnNhmT3EZTsKtofJlMox1jkMxdedILury74PwUbQBjWgo4tL4kf7uTAjU55mgQwjdzqakSTjkf+E1imrFwjnA==",
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -2133,9 +2133,9 @@
       "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "requires": {
         "ms": "2.1.2"
       },
@@ -2507,9 +2507,9 @@
       }
     },
     "nodemon": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
-      "integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.3.tgz",
+      "integrity": "sha512-m4Vqs+APdKzDFpuaL9F9EVOF85+h070FnkHVEoU4+rmT6Vw0bmNl7s61VEkY/cJkL7RCv1p4urnUDUMrS5rk2w==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.2",
@@ -2677,9 +2677,9 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "ramda": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.0.tgz",
-      "integrity": "sha512-13Y0iMhIQuAm/wNGBL/9HEqIfRGmNmjKnTPlKWfA9f7dnDkr8d45wQ+S7+ZLh/Pq9PdcGxkqKUEA7ySu1QSd9Q=="
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
+      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw=="
     },
     "rc": {
       "version": "1.2.8",
@@ -3023,9 +3023,9 @@
       }
     },
     "workerpool": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.1.tgz",
-      "integrity": "sha512-EFoFTSEo9m4V4wNrwzVRjxnf/E/oBpOzcI/R5CIugJhl9RsCiq525rszo4AtqcjQQoqFdu2E3H82AnbtpaQHvg=="
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.2.tgz",
+      "integrity": "sha512-5wZwyy5lcqrakQQcjaYQgVCbMR3djwIFWXuD2EGk/o/9bL3bd2kRGNwF74Bhcf1CIkAIwoOMG82EVnA5JmVVNw=="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -3038,9 +3038,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "zod": {
-      "version": "3.23.7",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.7.tgz",
-      "integrity": "sha512-NBeIoqbtOiUMomACV/y+V3Qfs9+Okr18vR5c/5pHClPpufWOrsx8TENboDPe265lFdfewX2yBtNTLPvnmCxwog=="
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
     }
   }
 }

--- a/servers/cu/package.json
+++ b/servers/cu/package.json
@@ -16,11 +16,11 @@
     "@permaweb/ao-scheduler-utils": "^0.0.19",
     "arweave": "^1.15.1",
     "async-lock": "^1.4.1",
-    "better-sqlite3": "^9.6.0",
+    "better-sqlite3": "^11.0.0",
     "bytes": "^3.1.2",
     "cors": "^2.8.5",
     "dataloader": "^2.2.2",
-    "debug": "^4.3.4",
+    "debug": "^4.3.5",
     "dotenv": "^16.4.5",
     "fast-glob": "^3.3.2",
     "fastify": "^4.27.0",
@@ -30,13 +30,13 @@
     "ms": "^2.1.3",
     "p-map": "^7.0.2",
     "prom-client": "^15.1.2",
-    "ramda": "^0.30.0",
+    "ramda": "^0.30.1",
     "warp-arbundles": "^1.0.4",
-    "workerpool": "^9.1.1",
-    "zod": "^3.23.7"
+    "workerpool": "^9.1.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
-    "nodemon": "^3.1.0"
+    "nodemon": "^3.1.3"
   },
   "engines": {
     "node": ">=18",


### PR DESCRIPTION
Just some housekeeping. `10` of `better-sqlite3` ships with Node 22 bindings, which should help reduce dependency install times.