### PR TITLE
Instrument CU http endpoints

### DIFF
--- a/servers/cu/README.md
+++ b/servers/cu/README.md
@@ -72,8 +72,6 @@ There are a few environment variables that you can set. Besides
   or is remote to the CU. Can be either `embedded` or `remote` (defaults to
   `embedded`)
 - `DB_URL`: the name of the embdeeded database (defaults to `ao-cache`)
-- `DUMP_PATH`: the path to send `heap` snapshots to. (See
-  [Heap Snapshots](#heap-snapshot))
 - `PROCESS_WASM_MEMORY_MAX_LIMIT`: The maximum `Memory-Limit`, in bytes,
   supported for `ao` processes (defaults to `1GB`)
 - `PROCESS_WASM_COMPUTE_MAX_LIMIT`: The maximum `Compute-Limit`, in bytes,

--- a/servers/cu/src/config.js
+++ b/servers/cu/src/config.js
@@ -34,8 +34,7 @@ const DEFAULT_PROCESS_WASM_MODULE_FORMATS = ['wasm32-unknown-emscripten', 'wasm3
 const serverConfigSchema = domainConfigSchema.extend({
   MODE: z.enum(['development', 'production']),
   port: positiveIntSchema,
-  ENABLE_METRICS_ENDPOINT: z.preprocess((val) => !!val, z.boolean()),
-  DUMP_PATH: z.string().min(1)
+  ENABLE_METRICS_ENDPOINT: z.preprocess((val) => !!val, z.boolean())
 })
 
 /**

--- a/servers/cu/src/routes/cron.js
+++ b/servers/cu/src/routes/cron.js
@@ -1,7 +1,7 @@
 import { always, compose, identity } from 'ramda'
 import { z } from 'zod'
 
-import { withMiddleware, withProcessRestrictionFromPath } from './middleware/index.js'
+import { withMetrics, withMiddleware, withProcessRestrictionFromPath } from './middleware/index.js'
 
 /**
  * TODO: could be moved into a route utils or middleware
@@ -37,6 +37,7 @@ export const withCronRoutes = app => {
     '/cron/:processId',
     compose(
       withMiddleware,
+      withMetrics({ tracesFrom: (req) => ({ process_id: req.params.processId }) }),
       withProcessRestrictionFromPath,
       always(async (req, res) => {
         const {

--- a/servers/cu/src/routes/dryRun.js
+++ b/servers/cu/src/routes/dryRun.js
@@ -2,7 +2,7 @@ import { always, compose } from 'ramda'
 import { z } from 'zod'
 
 import { busyIn } from '../domain/utils.js'
-import { withMiddleware, withProcessRestrictionFromQuery } from './middleware/index.js'
+import { withMetrics, withMiddleware, withProcessRestrictionFromQuery } from './middleware/index.js'
 
 const inputSchema = z.object({
   processId: z.string().min(1, 'a process-id query parameter is required'),
@@ -28,6 +28,7 @@ export const withDryRunRoutes = app => {
     '/dry-run',
     compose(
       withMiddleware,
+      withMetrics({ tracesFrom: (req) => ({ process_id: req.query['process-id'] }) }),
       withProcessRestrictionFromQuery,
       always(async (req, res) => {
         const {

--- a/servers/cu/src/routes/middleware/index.js
+++ b/servers/cu/src/routes/middleware/index.js
@@ -4,6 +4,7 @@ import { withErrorHandler } from './withErrorHandler.js'
 import { withDomain } from './withDomain.js'
 
 export * from './withProcessRestriction.js'
+export * from './withMetrics.js'
 
 /**
  * A convenience method that composes common middleware needed on most routes,

--- a/servers/cu/src/routes/middleware/withMetrics.js
+++ b/servers/cu/src/routes/middleware/withMetrics.js
@@ -1,0 +1,51 @@
+import { always } from 'ramda'
+import PromClient from 'prom-client'
+
+import { histogramWith } from '../../domain/client/metrics.js'
+
+PromClient.register.setContentType(PromClient.Registry.OPENMETRICS_CONTENT_TYPE)
+
+const histogram = histogramWith()({
+  name: 'http_request_duration_seconds',
+  description: 'Request duration in seconds',
+  buckets: [0.5, 1, 3, 5, 10, 30],
+  labelNames: ['method', 'route', 'status', 'statusGroup']
+})
+
+/**
+ * A middleware that, given functions to generate custom labels and traces,
+ * returns a function that, given the next handler in the chain, will
+ * observe the request time, and adds it to the histogram.
+ *
+ * This can be composed onto any route, to gather http duration metrics, along
+ * with tracesFrom to add per-request traces ie. process id
+ */
+export const withMetrics = ({ labelsFrom = always({}), tracesFrom = always({}) }) => {
+  function labelsFromReq (req) {
+    return {
+      ...labelsFrom(req),
+      /**
+       * See https://fastify.dev/docs/latest/reference/request
+       */
+      method: req.method,
+      route: req.routeOptions.url
+    }
+  }
+
+  function labelsFromRes (res) {
+    return {
+      status: res.statusCode,
+      statusGroup: `${Math.floor(res.statusCode / 100)}xx`
+    }
+  }
+
+  return (handler) => (req, res) => {
+    const reqLabels = labelsFromReq(req)
+    const traces = tracesFrom(req)
+    const stop = histogram.startTimer(reqLabels, traces)
+
+    return Promise.resolve()
+      .then(() => handler(req, res))
+      .finally(() => stop(labelsFromRes(res), traces))
+  }
+}

--- a/servers/cu/src/routes/result.js
+++ b/servers/cu/src/routes/result.js
@@ -2,7 +2,7 @@ import { compose } from 'ramda'
 import { z } from 'zod'
 
 import { busyIn } from '../domain/utils.js'
-import { withMiddleware, withProcessRestrictionFromQuery } from './middleware/index.js'
+import { withMetrics, withMiddleware, withProcessRestrictionFromQuery } from './middleware/index.js'
 import { withInMemoryCache } from './middleware/withInMemoryCache.js'
 
 const inputSchema = z.object({
@@ -15,6 +15,7 @@ export const withResultRoutes = app => {
     '/result/:messageTxId',
     compose(
       withMiddleware,
+      withMetrics({ tracesFrom: (req) => ({ process_id: req.query['process-id'] }) }),
       withProcessRestrictionFromQuery,
       withInMemoryCache({
         keyer: (req) => {

--- a/servers/cu/src/routes/results.js
+++ b/servers/cu/src/routes/results.js
@@ -1,6 +1,6 @@
 import { always, compose, identity } from 'ramda'
 
-import { withMiddleware, withProcessRestrictionFromPath } from './middleware/index.js'
+import { withMetrics, withMiddleware, withProcessRestrictionFromPath } from './middleware/index.js'
 import { z } from 'zod'
 
 /**
@@ -47,6 +47,7 @@ export const withResultsRoutes = app => {
     '/results/:processId',
     compose(
       withMiddleware,
+      withMetrics({ tracesFrom: (req) => ({ process_id: req.params.processId }) }),
       withProcessRestrictionFromPath,
       always(async (req, res) => {
         const {

--- a/servers/cu/src/routes/state.js
+++ b/servers/cu/src/routes/state.js
@@ -2,7 +2,7 @@ import { always, compose } from 'ramda'
 import { z } from 'zod'
 
 import { busyIn } from '../domain/utils.js'
-import { withMiddleware, withProcessRestrictionFromPath } from './middleware/index.js'
+import { withMetrics, withMiddleware, withProcessRestrictionFromPath } from './middleware/index.js'
 
 const inputSchema = z.object({
   processId: z.string().min(1, 'an ao process id is required'),
@@ -15,6 +15,7 @@ export const withStateRoutes = (app) => {
     '/state/:processId',
     compose(
       withMiddleware,
+      withMetrics({ tracesFrom: (req) => ({ process_id: req.params.processId }) }),
       withProcessRestrictionFromPath,
       always(async (req, res) => {
         const {


### PR DESCRIPTION
Closes #769 

This PR adds a middleware called `withMetrics`. Using simple function composition, we add this middleware onto each ao process-based route, which instruments the endpoint, adding it's metrics to the OpenTelemetry `/metrics` endpoint on the CU.

No additional dependencies. Just good ole' function composition.