### PR TITLE
perf(mu): cache potential CU redirect when fetching results #558

### DIFF
--- a/servers/mu/src/domain/clients/in-memory.js
+++ b/servers/mu/src/domain/clients/in-memory.js
@@ -3,12 +3,13 @@ import { LRUCache } from 'lru-cache'
 /**
  * @type {LRUCache}
  */
-export function createLruCache ({ size }) {
+export function createLruCache ({ size, ttl }) {
   const cache = new LRUCache({
     /**
      * number of entries
      */
     max: size,
+    ttl,
     /**
      * max size of cache, as a scalar.
      *

--- a/servers/mu/src/domain/index.js
+++ b/servers/mu/src/domain/index.js
@@ -31,8 +31,8 @@ const { DataItem } = warpArBundles
 const createDataItem = (raw) => new DataItem(raw)
 export { createLogger }
 
-const muRedirectCache = InMemoryClient.createLruCache({ size: 500 })
-
+const FIVE_MINUTES_IN_MS = 1000 * 60 * 5
+const muRedirectCache = InMemoryClient.createLruCache({ size: 500, ttl: FIVE_MINUTES_IN_MS })
 /**
  * A set of apis used by the express server
  * to send initial items and start the message

--- a/servers/mu/src/domain/lib/cu-fetch-with-cache.js
+++ b/servers/mu/src/domain/lib/cu-fetch-with-cache.js
@@ -1,0 +1,41 @@
+export function cuFetchWithCache ({ fetch, cache, logger }) {
+  logger = logger.child('cuFetchWithCache')
+  function checkForRedirect (response) {
+    if ([301, 302, 307, 308].includes(response.status)) {
+      return response.headers.get('Location')
+    }
+    return undefined
+  }
+
+  async function runFetch (url, opts) {
+    const response = await fetch(url, {
+      ...opts,
+      redirect: 'manual'
+    })
+    const redirected = checkForRedirect(response)
+    if (redirected) {
+      const urlObject = new URL(url)
+      const processId = urlObject.searchParams.get('process-id')
+      if (processId) {
+        const redirectURL = new URL(redirected)
+        logger('inserting cu redirect into cache for process: %s redirect: %s', processId, redirectURL.host)
+        cache.set(processId, redirectURL.host)
+      }
+      return runFetch(redirected, opts)
+    }
+    return response
+  }
+
+  return async (url, opts) => {
+    const requestUrl = new URL(url)
+    const processId = requestUrl.searchParams.get('process-id')
+    const foundRedirectUrl = cache.get(processId)
+    if (foundRedirectUrl) {
+      logger('found redirect url in cache for process: %s redirect: %s', processId, foundRedirectUrl)
+      // only sets the host, the protocol will be reused from the passed in url
+      // this is a safe assumption because all CUs are implementing the same APIs over the same protocols
+      requestUrl.host = foundRedirectUrl
+    }
+    return runFetch(requestUrl.toString(), opts)
+  }
+}

--- a/servers/mu/src/domain/lib/cu-fetch-with-cache.test.js
+++ b/servers/mu/src/domain/lib/cu-fetch-with-cache.test.js
@@ -1,0 +1,64 @@
+import * as assert from 'node:assert'
+import { describe, test } from 'node:test'
+
+import * as InMemoryClient from '../clients/in-memory.js'
+import { cuFetchWithCache } from './cu-fetch-with-cache.js'
+import createLogger from '../logger.js'
+
+const logger = createLogger({ name: 'cu-fetch-with-cache.test' })
+
+describe('cuFetchWithCache', () => {
+  test('fetch works as it normally does', async () => {
+    const cache = InMemoryClient.createLruCache({ size: 1 })
+    const fetchWithCache = cuFetchWithCache({
+      cache,
+      fetch: async () => {
+        return new Response(
+          JSON.stringify({
+            message: 'Hello, world!'
+          })
+        )
+      },
+      logger
+    })
+
+    const response = await fetchWithCache('https://foo.bar')
+
+    assert.deepStrictEqual(await response.json(), {
+      message: 'Hello, world!'
+    })
+    console.log(cache)
+    assert.equal(cache.size, 0)
+  })
+
+  test('redirect response is cached', async () => {
+    const cache = InMemoryClient.createLruCache({ size: 1 })
+    const processId = '123'
+    const fetchWithCache = cuFetchWithCache({
+      cache,
+      fetch: async (url) => {
+        if (url.startsWith('https://foo.bar')) {
+          return new Response(null, {
+            status: 307,
+            headers: {
+              Location: 'https://bar.baz'
+            }
+          })
+        }
+        return new Response(
+          JSON.stringify({
+            message: 'Hello, world!'
+          })
+        )
+      },
+      logger
+    })
+
+    const response = await fetchWithCache(`https://foo.bar?process-id=${processId}`)
+
+    assert.deepStrictEqual(await response.json(), {
+      message: 'Hello, world!'
+    })
+    assert.equal(cache.get(processId), 'bar.baz')
+  })
+})


### PR DESCRIPTION
Closes #558 

Adds a new library utility to create a fetch function that is wrapped with a handler for redirects which writes to a passed in LRU cache so that subsequent requests will have their host set explicitly to the previously redirected url for the given process id

This is intended for use with the CU since URLs to be fetched include a processId in their query parameters and this is used as the cache key.