### PR TITLE
fix(connect): removes default export check causing error when importing

### DIFF
--- a/connect/src/client/node/wallet.js
+++ b/connect/src/client/node/wallet.js
@@ -3,11 +3,7 @@ import * as WarpArBundles from 'warp-arbundles'
 // eslint-disable-next-line no-unused-vars
 import { Types } from '../../dal.js'
 
-/**
- * hack to get module resolution working on node jfc
- */
-const pkg = WarpArBundles.default ? WarpArBundles.default : WarpArBundles
-const { createData, ArweaveSigner } = pkg
+const { createData, ArweaveSigner } = WarpArBundles
 
 /**
  * A function that builds a signer using a wallet jwk interface


### PR DESCRIPTION
Closes #526 

simply removes the default check as it seems that even just checking for default is causing the issue. The package indeed does not have a default export so we simply treat it as only having named exports.

Trying to used named imports throws the following error on test

```
import { createData, ArweaveSigner } from 'warp-arbundles'
                     ^^^^^^^^^^^^^
SyntaxError: Named export 'ArweaveSigner' not found. The requested module 'warp-arbundles' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'warp-arbundles';
const { createData, ArweaveSigner } = pkg;
```

which is where the initial fix comes from, moving this to treating it as a generic "default" import and then destructuring from there gets us the same rough output without the explicit default export check