### PR TITLE
feat(dev-cli): add file close function to aolib

### DIFF
--- a/dev-cli/container/build.sh
+++ b/dev-cli/container/build.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/bash
+#!/bin/sh
 
 docker build . -t p3rmaw3b/ao

--- a/dev-cli/container/src/aolibc/aostdio.c
+++ b/dev-cli/container/src/aolibc/aostdio.c
@@ -28,6 +28,11 @@ EM_ASYNC_JS(int, weavedrive_read, (int fd, int *dst_ptr, size_t length), {
     return Promise.resolve(await drive.read(fd, dst_ptr, length));
 });
 
+EM_ASYNC_JS(int, weavedrive_close, (int fd), {
+  const drive = Module.WeaveDrive(Module, FS);
+  return drive.close(fd);
+});
+
 FILE* fopen(const char* filename, const char* mode) {
     AO_LOG( "AO: Called fopen: %s, %s\n", filename, mode);
     int fd = weavedrive_open(filename, mode);
@@ -47,6 +52,8 @@ size_t fread(void* ptr, size_t size, size_t nmemb, FILE* stream) {
 
 int fclose(FILE* stream) {
      AO_LOG( "AO: fclose called\n");
+     int fd = fileno(stream);
+     weavedrive_close(fd);
      return 0;  // Returning success, adjust as necessary
 }
 

--- a/dev-cli/src/versions.js
+++ b/dev-cli/src/versions.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
 export const VERSION = {
-  "CLI": "0.0.56",
-  "IMAGE": "0.0.36"
+  "CLI": "0.0.57",
+  "IMAGE": "0.0.37"
 }


### PR DESCRIPTION
This PR is about updating the aolibc library to submit a file close to weave drive to close the file stream.