### PR TITLE
Jrdn91/process memory cache ttl

### DIFF
--- a/servers/cu/package-lock.json
+++ b/servers/cu/package-lock.json
@@ -24,6 +24,7 @@
         "fastify": "^4.27.0",
         "helmet": "^7.1.0",
         "hyper-async": "^1.1.2",
+        "long-timeout": "^0.1.1",
         "lru-cache": "^10.2.2",
         "ms": "^2.1.3",
         "p-map": "^7.0.2",
@@ -914,6 +915,11 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
       "integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA=="
+    },
+    "node_modules/long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
     },
     "node_modules/lru-cache": {
       "version": "10.2.2",
@@ -2450,6 +2456,11 @@
           "integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA=="
         }
       }
+    },
+    "long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
     },
     "lru-cache": {
       "version": "10.2.2",

--- a/servers/cu/package.json
+++ b/servers/cu/package.json
@@ -27,6 +27,7 @@
     "fastify": "^4.27.0",
     "helmet": "^7.1.0",
     "hyper-async": "^1.1.2",
+    "long-timeout": "^0.1.1",
     "lru-cache": "^10.2.2",
     "ms": "^2.1.3",
     "p-map": "^7.0.2",

--- a/servers/cu/src/domain/client/ao-process.js
+++ b/servers/cu/src/domain/client/ao-process.js
@@ -47,7 +47,14 @@ export const LATEST = 'LATEST'
  * @prop {string} [cron]
  */
 let processMemoryCache
-export async function createProcessMemoryCache ({ MAX_SIZE, TTL, DRAIN_TO_FILE_THRESHOLD, gauge, onEviction, writeProcessMemoryFile }) {
+
+/**
+ * setTimeout is passed in as a dependency here because in a few instances such as TTL timeout, a value greater than the safe integer limit is used
+ * which causes setTimeout to overflow and return immediately. Allowing the caller to pass in their own setTimeout function allows them to handle this
+ * via passing in a new implementation such as using the 'long-timeout' library
+ * This resolves issue #666
+ */
+export async function createProcessMemoryCache ({ MAX_SIZE, TTL, DRAIN_TO_FILE_THRESHOLD, gauge, onEviction, writeProcessMemoryFile, setTimeout, clearTimeout }) {
   if (processMemoryCache) return processMemoryCache
 
   const clearTimerWith = (map) => (key) => {

--- a/servers/cu/src/domain/index.js
+++ b/servers/cu/src/domain/index.js
@@ -20,6 +20,7 @@ import * as AoModuleClient from './client/ao-module.js'
 import * as AoEvaluationClient from './client/ao-evaluation.js'
 import * as AoBlockClient from './client/ao-block.js'
 import * as MetricsClient from './client/metrics.js'
+import lt from 'long-timeout'
 
 import { readResultWith } from './api/readResult.js'
 import { readStateWith, pendingReadStates } from './api/readState.js'
@@ -185,7 +186,9 @@ export const createApis = async (ctx) => {
             value.evaluation,
             err
           )
-        })
+        }),
+    setTimeout: (...args) => lt.setTimeout(...args),
+    clearTimeout: (...args) => lt.clearTimeout(...args)
   })
 
   const sharedDeps = (logger) => ({


### PR DESCRIPTION
closes #666 👿 

We are installing a new library `long-timeout` which can handle times longer than the max safe integer.
I have added a comment block to the main function to explain why this update is being made to force the code to pass in `setTimeout` as as dependency.