### PR TITLE
fix(connect): add note to readme about usage with Next.js

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -14,6 +14,7 @@ This module will run in a browser or server environment.
 - [Usage](#usage)
     - [ESM (Node & Browser) aka type: `module`](#esm-node--browser-aka-type-module)
     - [CJS (Node) type: `commonjs`](#cjs-node-type-commonjs)
+    - [Usage with NextJS App Router](#usage-with-nextjs-app-router)
   - [API](#api)
     - [`result`](#result)
     - [`results`](#results)
@@ -49,6 +50,29 @@ const { spawn, message, result } = require("@permaweb/aoconnect");
 ```
 
 The duration of this document will use `ESM` for examples
+
+#### Usage with NextJS App Router
+
+If you're using AO Connect with the NextJS App Router, there is additional setup required to circumvent a known issue. See the NextJS Issue [here](https://github.com/vercel/next.js/discussions/49120) and [here](https://github.com/vercel/next.js/issues/32714) and Webpack issue [here](https://github.com/webpack/webpack/issues/4674)
+
+```
+// next.config.mjs
+import path from "path";
+...
+const nextConfig = {
+  webpack: (config, { isServer }) => {
+    // Add the alias to the webpack configuration
+    config.resolve.alias["@permaweb/aoconnect"] = path.resolve(
+      process.cwd(),
+      "node_modules/@permaweb/aoconnect/dist/browser"
+    );
+
+    // Return the modified config
+    return config;
+  },
+};
+...
+```
 
 ### API
 


### PR DESCRIPTION
This is a README update to explain and show a fix for using the AOConnect package with Next.js

Closes #526 