### PR TITLE
perf(mu): add metrics middleware for http requests #802

### DIFF
--- a/servers/mu/src/routes/middleware/index.js
+++ b/servers/mu/src/routes/middleware/index.js
@@ -3,6 +3,8 @@ import { compose } from 'ramda'
 import { withErrorHandler } from './withErrorHandler.js'
 import { withDomain } from './withDomain.js'
 
+export * from './withMetrics.js'
+
 /**
  * A convenience method that composes common middleware needed on most routes,
  * such that other routes can simply compose this one middleware.

--- a/servers/mu/src/routes/middleware/withMetrics.js
+++ b/servers/mu/src/routes/middleware/withMetrics.js
@@ -1,0 +1,48 @@
+import { always } from 'ramda'
+
+import { histogramWith } from '../../domain/clients/metrics.js'
+
+const histogram = histogramWith()({
+  name: 'http_request_duration_seconds',
+  description: 'Request duration in seconds',
+  buckets: [0.5, 1, 3, 5, 10, 30],
+  labelNames: ['method', 'route', 'status', 'statusGroup']
+})
+
+/**
+ * A middleware that, given functions to generate custom labels and traces,
+ * returns a function that, given the next handler in the chain, will
+ * observe the request time, and adds it to the histogram.
+ *
+ * This can be composed onto any route, to gather http duration metrics, along
+ * with tracesFrom to add per-request traces ie. process id
+ */
+export const withMetrics = ({ labelsFrom = always({}), tracesFrom = always({}) } = {}) => {
+  function labelsFromReq (req) {
+    return {
+      ...labelsFrom(req),
+      /**
+       * See https://expressjs.com/en/api.html#req
+       */
+      method: req.method,
+      route: req.route.path
+    }
+  }
+
+  function labelsFromRes (res) {
+    return {
+      status: res.statusCode,
+      statusGroup: `${Math.floor(res.statusCode / 100)}xx`
+    }
+  }
+
+  return (handler) => (req, res) => {
+    const reqLabels = labelsFromReq(req)
+    const traces = tracesFrom(req)
+    const stop = histogram.startTimer(reqLabels, traces)
+
+    return Promise.resolve()
+      .then(() => handler(req, res))
+      .finally(() => stop(labelsFromRes(res), traces))
+  }
+}

--- a/servers/mu/src/routes/monitor.js
+++ b/servers/mu/src/routes/monitor.js
@@ -3,7 +3,7 @@ import { of } from 'hyper-async'
 // import { z } from 'zod'
 // import WarpArBundles from 'warp-arbundles'
 
-import { withMiddleware } from './middleware/index.js'
+import { withMetrics, withMiddleware } from './middleware/index.js'
 
 // const { DataItem } = WarpArBundles
 
@@ -20,6 +20,7 @@ export const withMonitorRoutes = (app) => {
     '/monitor/:processId',
     compose(
       withMiddleware,
+      withMetrics({ tracesFrom: (req) => ({ process_id: req.params['process-id'] }) }),
       always(async (req, res) => {
         const {
           body,

--- a/servers/mu/src/routes/root.js
+++ b/servers/mu/src/routes/root.js
@@ -5,7 +5,7 @@ import { z } from 'zod'
 // arbundles verifies cross chain signed data items, warp-arbundles only supports arweave
 import { DataItem } from 'arbundles'
 
-import { withMiddleware } from './middleware/index.js'
+import { withMetrics, withMiddleware } from './middleware/index.js'
 
 // const { DataItem } = WarpArBundles
 
@@ -101,6 +101,7 @@ const withBaseRoute = (app) => {
     '/',
     compose(
       withMiddleware,
+      withMetrics(),
       always(async (_req, res) => {
         return res.send('ao messenger unit')
       })


### PR DESCRIPTION
This copies the `withMetrics` middleware from the CU and implements it across both the monitor endpoint and the root endpoint