### PR TITLE
feat: add .vscode folder to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 wallet.json
 dist
 .VSCodeCounter
+.vscode
 node_modules
 foo.js
 .env


### PR DESCRIPTION
My editor has some settings that has it attempting to auto fix and what not for other linting tools, this update allows anyone using visual studio code to add a `.vscode` folder with settings etc. to turn off extensions or change defaulted settings to better cooperate with the repo and ensure those settings don't get tracked in for everyone