### PR TITLE
chore: update ao build image to use 41 MB stacksize

### DIFF
--- a/dev-cli/container/src/emcc-lua
+++ b/dev-cli/container/src/emcc-lua
@@ -168,8 +168,10 @@ def main():
       '-g2',
       '-s', 'ASYNCIFY=1',
       '-s', 'MEMORY64=1',
+      '-s', 'STACK_SIZE=41943040',
+      '-s', 'ASYNCIFY_STACK_SIZE=41943040',
       '-s', 'ALLOW_MEMORY_GROWTH=1', 
-      '-s', 'INITIAL_MEMORY=6291456', 
+      '-s', 'INITIAL_MEMORY=52428800', 
       '-s', 'MAXIMUM_MEMORY=524288000', 
       '-s', 'WASM=1', 
       '-s', 'MODULARIZE', 
@@ -188,7 +190,7 @@ def main():
     cmd.extend([quote(v.filepath) for v in link_libraries])
     cmd.extend([quote(v.filepath) for v in link_libraries])
 
-    cmd.extend(['-s', 'EXPORTED_FUNCTIONS=["_malloc"]'])
+    cmd.extend(['-s', 'EXPORTED_FUNCTIONS=["_malloc", "_main"]'])
     cmd.extend(['-lm', '-ldl', '-o', definition.get_output_file(), '-s', 'EXPORTED_RUNTIME_METHODS=["cwrap"]'])
 
     debug_print('Compile command is {}'.format(' '.join(cmd)))

--- a/dev-cli/src/versions.js
+++ b/dev-cli/src/versions.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
 export const VERSION = {
   "CLI": "0.0.58",
-  "IMAGE": "0.0.38"
+  "IMAGE": "0.0.39"
 }


### PR DESCRIPTION
This PR builds a new AOS module with 41MB stacksize