### PR TITLE
fix(mu): empty procs.json error catch

### DIFF
--- a/servers/mu/src/domain/clients/cron.js
+++ b/servers/mu/src/domain/clients/cron.js
@@ -35,12 +35,17 @@ function initCronProcsWith ({ PROC_FILE_PATH, startMonitoredProcess }) {
     if (!fs.existsSync(PROC_FILE_PATH)) return
     const data = fs.readFileSync(PROC_FILE_PATH, 'utf8')
 
-    /**
-     * This .replace is used to fix corrupted json files
-     * it should be removed later now that the corruption
-     * issue is solved
-     */
-    const obj = JSON.parse(data.replace(/}\s*"/g, ',"'))
+    let obj
+    try {
+      /**
+       * This .replace is used to fix corrupted json files
+       * it should be removed later now that the corruption
+       * issue is solved
+       */
+      obj = JSON.parse(data.replace(/}\s*"/g, ',"'))
+    } catch (_e) {
+      obj = {}
+    }
 
     /*
      * start new os procs when the server starts because


### PR DESCRIPTION
Closes #811 

Unable to reproduce error where procs.json was emptied out. However, added try catch to parsing of file to catch error and replace with {}. Works with empty or corrupted procs file.