### PR TITLE
fix(mu): better error message when unmonitoring untracked processes #796

### DIFF
--- a/servers/mu/src/domain/clients/cron.js
+++ b/servers/mu/src/domain/clients/cron.js
@@ -160,6 +160,10 @@ function startMonitoredProcessWith ({ logger, CRON_CURSOR_DIR, CU_URL, fetchCron
 function killMonitoredProcessWith ({ logger, PROC_FILE_PATH }) {
   return async ({ processId }) => {
     const ct = cronsRunning[processId]
+    if (!ct) {
+      logger(`Cron process not found: ${processId}`)
+      throw new Error('Process monitor not found')
+    }
     ct.stop()
     delete cronsRunning[processId]
     delete procsToSave[processId]


### PR DESCRIPTION
Closes #796 

Was able to recreate issue - error throws when unmonitoring an untracked process. The error message is fairly unclear, so added thrown error explaining issue. Generally, though, working as intending.