### PR TITLE
perf(mu): Implement outgoing http Metrics #826

### DIFF
--- a/servers/mu/src/domain/clients/cron.js
+++ b/servers/mu/src/domain/clients/cron.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import cron from 'node-cron'
 import { Mutex } from 'async-mutex'
+import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
 
 const mutex = new Mutex()
 /**
@@ -61,7 +62,14 @@ function initCronProcsWith ({ PROC_FILE_PATH, startMonitoredProcess }) {
   }
 }
 
-function startMonitoredProcessWith ({ logger, CRON_CURSOR_DIR, CU_URL, fetchCron, crank, PROC_FILE_PATH }) {
+function startMonitoredProcessWith ({ fetch, histogram, logger, CRON_CURSOR_DIR, CU_URL, fetchCron, crank, PROC_FILE_PATH }) {
+  const getCursorFetch = withTimerMetricsFetch({
+    fetch,
+    histogram,
+    startLabelsFrom: () => ({
+      operation: 'getCursor'
+    })
+  })
   return async ({ processId }) => {
     if (cronsRunning[processId]) {
       throw new Error('Process already being monitored')
@@ -137,7 +145,7 @@ function startMonitoredProcessWith ({ logger, CRON_CURSOR_DIR, CU_URL, fetchCron
         return fs.readFileSync(cursorFilePath, 'utf8')
       }
 
-      const latestResults = await fetch(`${CU_URL}/results/${processId}?sort=DESC&limit=1&processId=${processId}`)
+      const latestResults = await getCursorFetch(`${CU_URL}/results/${processId}?sort=DESC&limit=1&processId=${processId}`)
 
       const latestJson = await latestResults.json()
         .catch(error => {

--- a/servers/mu/src/domain/clients/gateway.js
+++ b/servers/mu/src/domain/clients/gateway.js
@@ -1,6 +1,22 @@
 import { backoff, okRes } from '../utils.js'
+import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
 
-function isWalletWith ({ fetch, GRAPHQL_URL, logger, setById, getById }) {
+function isWalletWith ({
+  fetch,
+  histogram,
+  GRAPHQL_URL,
+  logger,
+  setById,
+  getById
+}) {
+  const walletFetch = withTimerMetricsFetch({
+    fetch,
+    histogram,
+    startLabelsFrom: () => ({
+      operation: 'isWallet'
+    })
+  })
+
   return async (id) => {
     logger(`Checking if id is a wallet ${id}`)
 
@@ -19,8 +35,16 @@ function isWalletWith ({ fetch, GRAPHQL_URL, logger, setById, getById }) {
       either a wallet or something else.
     */
     return backoff(
-      () => fetch(`${GRAPHQL_URL.replace('/graphql', '')}/${id}`, { method: 'HEAD' }).then(okRes),
-      { maxRetries: 3, delay: 500, log: logger, name: `isWalletOnGateway(${id})` }
+      () =>
+        walletFetch(`${GRAPHQL_URL.replace('/graphql', '')}/${id}`, {
+          method: 'HEAD'
+        }).then(okRes),
+      {
+        maxRetries: 3,
+        delay: 500,
+        log: logger,
+        name: `isWalletOnGateway(${id})`
+      }
     )
       .then((res) => {
         return setById(id, { isWallet: !res.ok }).then(() => {

--- a/servers/mu/src/domain/clients/scheduler.js
+++ b/servers/mu/src/domain/clients/scheduler.js
@@ -1,44 +1,58 @@
 import { identity } from 'ramda'
 import { of, fromPromise, Rejected } from 'hyper-async'
 import { backoff, okRes } from '../utils.js'
+import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
 
-function writeDataItemWith ({ fetch, logger }) {
+function writeDataItemWith ({ fetch, histogram, logger }) {
+  const suFetch = withTimerMetricsFetch({
+    fetch,
+    histogram,
+    startLabelsFrom: () => ({
+      operation: 'writeDataItem'
+    })
+  })
+  const suRedirectFetch = withTimerMetricsFetch({
+    fetch,
+    histogram,
+    startLabelsFrom: () => ({
+      operation: 'writeDataItemWithRedirect'
+    })
+  })
   return async ({ data, suUrl }) => {
     return of(Buffer.from(data, 'base64'))
       .map(logger.tap(`Forwarding message to SU ${suUrl}`))
-      .chain(fromPromise((body) =>
-        fetch(suUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/octet-stream',
-            Accept: 'application/json'
-          },
-          redirect: 'manual',
-          body
-        }).then(async response => {
-          /*
+      .chain(
+        fromPromise((body) =>
+          suFetch(suUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/octet-stream',
+              Accept: 'application/json'
+            },
+            redirect: 'manual',
+            body
+          }).then(async (response) => {
+            /*
             After upgrading to node 22 we have to handle
             the redirects manually otherwise fetch throws
             an error
           */
-          if ([307, 308].includes(response.status)) {
-            const newUrl = response.headers.get('Location')
-            return fetch(newUrl, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                Accept: 'application/json'
-              },
-              body
-            })
-          }
-          return response
-        })
-      ))
-      .bimap(
-        logger.tap('Error while communicating with SU:'),
-        identity
+            if ([307, 308].includes(response.status)) {
+              const newUrl = response.headers.get('Location')
+              return suRedirectFetch(newUrl, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/octet-stream',
+                  Accept: 'application/json'
+                },
+                body
+              })
+            }
+            return response
+          })
+        )
       )
+      .bimap(logger.tap('Error while communicating with SU:'), identity)
       .bichain(
         (err) => Rejected(JSON.stringify(err)),
         fromPromise(async (res) => {
@@ -54,52 +68,74 @@ function writeDataItemWith ({ fetch, logger }) {
   }
 }
 
-function writeAssignmentWith ({ fetch, logger }) {
+function writeAssignmentWith ({ fetch, histogram, logger }) {
+  const suFetch = withTimerMetricsFetch({
+    fetch,
+    histogram,
+    startLabelsFrom: () => ({
+      operation: 'writeAssignment'
+    })
+  })
+  const suRedirectFetch = withTimerMetricsFetch({
+    fetch,
+    histogram,
+    startLabelsFrom: () => ({
+      operation: 'writeAssignmentWithRedirect'
+    })
+  })
   return async ({ txId, processId, baseLayer, exclude, suUrl }) => {
     return of({ txId, processId, baseLayer, exclude, suUrl })
       .map(logger.tap(`Forwarding Assignment to SU ${suUrl}`))
-      .chain(fromPromise(({ txId, processId, baseLayer, exclude, suUrl }) => {
-        let url = `${suUrl}/?process-id=${processId}&assign=${txId}`
-        // aop2 base-layer param
-        if (baseLayer === '') {
-          url += '&base-layer'
-        }
-        // aop1 exclude param
-        if (exclude) {
-          url += `&exclude=${exclude}`
-        }
-
-        return backoff(
-          () => fetch(url, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/octet-stream',
-              Accept: 'application/json'
-            },
-            redirect: 'manual'
-          }).then((res) => {
-            return okRes(res)
-          }),
-          { maxRetries: 5, delay: 500, log: logger, name: `forwardAssignment(${JSON.stringify({ suUrl, processId, txId })})` }
-        ).then(response => {
-          if ([307, 308].includes(response.status)) {
-            const newUrl = response.headers.get('Location')
-            return fetch(newUrl, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                Accept: 'application/json'
-              }
-            })
+      .chain(
+        fromPromise(({ txId, processId, baseLayer, exclude, suUrl }) => {
+          let url = `${suUrl}/?process-id=${processId}&assign=${txId}`
+          // aop2 base-layer param
+          if (baseLayer === '') {
+            url += '&base-layer'
           }
-          return response
+          // aop1 exclude param
+          if (exclude) {
+            url += `&exclude=${exclude}`
+          }
+
+          return backoff(
+            () =>
+              suFetch(url, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/octet-stream',
+                  Accept: 'application/json'
+                },
+                redirect: 'manual'
+              }).then((res) => {
+                return okRes(res)
+              }),
+            {
+              maxRetries: 5,
+              delay: 500,
+              log: logger,
+              name: `forwardAssignment(${JSON.stringify({
+                suUrl,
+                processId,
+                txId
+              })})`
+            }
+          ).then((response) => {
+            if ([307, 308].includes(response.status)) {
+              const newUrl = response.headers.get('Location')
+              return suRedirectFetch(newUrl, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/octet-stream',
+                  Accept: 'application/json'
+                }
+              })
+            }
+            return response
+          })
         })
-      }
-      ))
-      .bimap(
-        logger.tap('Error while communicating with SU:'),
-        identity
       )
+      .bimap(logger.tap('Error while communicating with SU:'), identity)
       .bichain(
         (err) => Rejected(JSON.stringify(err)),
         fromPromise(async (res) => {
@@ -115,19 +151,33 @@ function writeAssignmentWith ({ fetch, logger }) {
   }
 }
 
-function fetchSchedulerProcessWith ({ fetch, logger, setByProcess, getByProcess }) {
+function fetchSchedulerProcessWith ({
+  fetch,
+  histogram,
+  logger,
+  setByProcess,
+  getByProcess
+}) {
+  const suFetch = withTimerMetricsFetch({
+    fetch,
+    histogram,
+    startLabelsFrom: () => ({
+      operation: 'writeAssignmentWithRedirect'
+    })
+  })
   return (processId, suUrl) => {
     return getByProcess(processId)
-      .then(cached => {
+      .then((cached) => {
         if (cached) {
           logger(`cached process found ${processId}`)
           return cached
         }
 
         logger(`${suUrl}/processes/${processId}`)
-        return fetch(`${suUrl}/processes/${processId}`)
-          .then(res => res.json())
-          .then(res => {
+
+        return suFetch(`${suUrl}/processes/${processId}`)
+          .then((res) => res.json())
+          .then((res) => {
             if (res) {
               return setByProcess(processId, res).then(() => res)
             }

--- a/servers/mu/src/domain/clients/uploader.js
+++ b/servers/mu/src/domain/clients/uploader.js
@@ -1,24 +1,31 @@
 import { identity } from 'ramda'
 import { of, fromPromise, Rejected } from 'hyper-async'
+import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
 
-function uploadDataItemWith ({ UPLOADER_URL, fetch, logger }) {
+function uploadDataItemWith ({ UPLOADER_URL, fetch, histogram, logger }) {
+  const dataItemFetch = withTimerMetricsFetch({
+    fetch,
+    histogram,
+    startLabelsFrom: () => ({
+      operation: 'uploadDataItem'
+    })
+  })
   return async (data) => {
     return of(data)
       .map(logger.tap(`Forwarding message to uploader ${UPLOADER_URL}`))
-      .chain(fromPromise((body) =>
-        fetch(`${UPLOADER_URL}/tx/arweave`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/octet-stream',
-            Accept: 'application/json'
-          },
-          body
-        })
-      ))
-      .bimap(
-        logger.tap('Error while communicating with uploader:'),
-        identity
+      .chain(
+        fromPromise((body) =>
+          dataItemFetch(`${UPLOADER_URL}/tx/arweave`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/octet-stream',
+              Accept: 'application/json'
+            },
+            body
+          })
+        )
       )
+      .bimap(logger.tap('Error while communicating with uploader:'), identity)
       .bichain(
         (err) => Rejected(JSON.stringify(err)),
         fromPromise(async (res) => {

--- a/servers/mu/src/domain/index.js
+++ b/servers/mu/src/domain/index.js
@@ -34,6 +34,13 @@ export { createLogger }
 const FIVE_MINUTES_IN_MS = 1000 * 60 * 5
 const SIXTY_MINUTES_IN_MS = 1000 * 60 * 60
 const muRedirectCache = InMemoryClient.createLruCache({ size: 500, ttl: FIVE_MINUTES_IN_MS })
+const histogram = MetricsClient.histogramWith()({
+  name: 'outgoing_http_request_duration_seconds',
+  description: 'Outgoing request duration in seconds',
+  buckets: [0.5, 1, 3, 5, 10, 30],
+  labelNames: ['method', 'operation', 'errorType', 'status', 'statusGroup']
+})
+
 /**
  * A set of apis used by the express server
  * to send initial items and start the message
@@ -100,13 +107,13 @@ export const createApis = async (ctx) => {
     createDataItem,
     locateScheduler: raw,
     locateProcess: locate,
-    writeDataItem: schedulerClient.writeDataItemWith({ fetch, logger: sendDataItemLogger }),
-    fetchResult: cuClient.resultWith({ fetch: fetchWithCache, CU_URL, logger: sendDataItemLogger }),
-    fetchSchedulerProcess: schedulerClient.fetchSchedulerProcessWith({ getByProcess, setByProcess, fetch, logger: sendDataItemLogger }),
+    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: sendDataItemLogger }),
+    fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: sendDataItemLogger }),
+    fetchSchedulerProcess: schedulerClient.fetchSchedulerProcessWith({ getByProcess, setByProcess, fetch, histogram, logger: sendDataItemLogger }),
     crank,
-    isWallet: gatewayClient.isWalletWith({ fetch, GRAPHQL_URL: ctx.GRAPHQL_URL, logger: sendDataItemLogger }),
+    isWallet: gatewayClient.isWalletWith({ fetch, histogram, GRAPHQL_URL: ctx.GRAPHQL_URL, logger: sendDataItemLogger }),
     logger: sendDataItemLogger,
-    writeDataItemArweave: uploaderClient.uploadDataItemWith({ UPLOADER_URL, logger: sendDataItemLogger, fetch })
+    writeDataItemArweave: uploaderClient.uploadDataItemWith({ UPLOADER_URL, logger: sendDataItemLogger, fetch, histogram })
   })
 
   const sendAssignLogger = logger.child('sendAssign')
@@ -114,14 +121,16 @@ export const createApis = async (ctx) => {
     selectNode: cuClient.selectNodeWith({ CU_URL, logger: sendDataItemLogger }),
     locateProcess: locate,
     writeAssignment: schedulerClient.writeAssignmentWith({ fetch, logger: sendAssignLogger }),
-    fetchResult: cuClient.resultWith({ fetch: fetchWithCache, CU_URL, logger: sendDataItemLogger }),
+    fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: sendDataItemLogger }),
     crank,
     logger: sendAssignLogger
   })
 
   const monitorProcessLogger = logger.child('monitorProcess')
-  const fetchCron = fromPromise(cuClient.fetchCronWith({ CU_URL, logger: monitorProcessLogger }))
+  const fetchCron = fromPromise(cuClient.fetchCronWith({ fetch, histogram, CU_URL, logger: monitorProcessLogger }))
   const startProcessMonitor = cronClient.startMonitoredProcessWith({
+    fetch,
+    histogram,
     logger: monitorProcessLogger,
     PROC_FILE_PATH,
     CRON_CURSOR_DIR,
@@ -197,13 +206,13 @@ export const createResultApis = async (ctx) => {
     createDataItem,
     locateScheduler: raw,
     locateProcess: locate,
-    writeDataItem: schedulerClient.writeDataItemWith({ fetch, logger: processMsgLogger }),
-    fetchSchedulerProcess: schedulerClient.fetchSchedulerProcessWith({ getByProcess, setByProcess, fetch, logger: processMsgLogger }),
+    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: processMsgLogger }),
+    fetchSchedulerProcess: schedulerClient.fetchSchedulerProcessWith({ getByProcess, setByProcess, fetch, histogram, logger: processMsgLogger }),
     buildAndSign: signerClient.buildAndSignWith({ MU_WALLET, logger: processMsgLogger }),
-    fetchResult: cuClient.resultWith({ fetch: fetchWithCache, CU_URL, logger: processMsgLogger }),
+    fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: processMsgLogger }),
     logger,
-    isWallet: gatewayClient.isWalletWith({ fetch, GRAPHQL_URL: ctx.GRAPHQL_URL, logger: processMsgLogger, setById, getById }),
-    writeDataItemArweave: uploaderClient.uploadDataItemWith({ UPLOADER_URL, logger: processMsgLogger, fetch })
+    isWallet: gatewayClient.isWalletWith({ fetch, histogram, GRAPHQL_URL: ctx.GRAPHQL_URL, logger: processMsgLogger, setById, getById }),
+    writeDataItemArweave: uploaderClient.uploadDataItemWith({ UPLOADER_URL, logger: processMsgLogger, fetch, histogram })
   })
 
   const processSpawnLogger = logger.child('processSpawn')
@@ -213,14 +222,14 @@ export const createResultApis = async (ctx) => {
     locateProcess: locate,
     locateNoRedirect,
     buildAndSign: signerClient.buildAndSignWith({ MU_WALLET, logger: processMsgLogger }),
-    writeDataItem: schedulerClient.writeDataItemWith({ fetch, logger: processSpawnLogger })
+    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: processSpawnLogger })
   })
 
   const processAssignLogger = logger.child('processAssign')
   const processAssign = processAssignWith({
     logger: processSpawnLogger,
     locateProcess: locate,
-    fetchResult: cuClient.resultWith({ fetch: fetchWithCache, CU_URL, logger: processAssignLogger }),
+    fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: processAssignLogger }),
     writeAssignment: schedulerClient.writeAssignmentWith({ fetch, logger: processAssignLogger })
   })
   return {

--- a/servers/mu/src/domain/lib/with-timer-metrics-fetch.js
+++ b/servers/mu/src/domain/lib/with-timer-metrics-fetch.js
@@ -1,0 +1,46 @@
+import { logger } from '../../logger.js'
+import { withTimerMetrics } from './with-timer-metrics.js'
+import { always } from 'ramda'
+
+export const withTimerMetricsFetch = ({
+  timer,
+  fetch,
+  startLabelsFrom = always({}),
+  stopLabelsFrom = always({}),
+  tracesFrom = always({})
+}) => withTimerMetrics({
+  timer,
+  startLabelsFrom: (_url, fetchOptions = {}) => {
+    return {
+      ...startLabelsFrom(_url, fetchOptions),
+      method: fetchOptions.method ?? 'GET' // not passing method to fetch options defaults to a GET request
+    }
+  },
+  stopLabelsFrom: (res) => {
+    if (res instanceof Response === false) {
+      let errorType = ''
+      switch (true) {
+        case res instanceof DOMException:
+          errorType = res.name
+          break
+        case res instanceof TypeError:
+          errorType = 'typeError'
+          break
+        default:
+          errorType = 'unknownError'
+          break
+      }
+      return {
+        ...stopLabelsFrom(res),
+        errorType
+      }
+    }
+    return {
+      ...stopLabelsFrom(res),
+      status: res.status,
+      statusGroup: `${Math.floor(res.status / 100)}xx`
+    }
+  },
+  tracesFrom,
+  logger: logger('ao-mu-metrics')
+})(fetch)

--- a/servers/mu/src/domain/lib/with-timer-metrics-fetch.test.js
+++ b/servers/mu/src/domain/lib/with-timer-metrics-fetch.test.js
@@ -1,0 +1,71 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { withTimerMetricsFetch } from './with-timer-metrics-fetch.js'
+
+describe('withTimerMetricsFetch', () => {
+  describe('should start and stop the timer with expected labels and traces', () => {
+    test('when the original function is successful', async () => {
+      let startTimerCalled = false
+      let stopTimerCalled = false
+      const metricsFunction = withTimerMetricsFetch({
+        timer: {
+          startTimer (startLabels, traces) {
+            startTimerCalled = true
+            assert.deepEqual(startLabels, { foo: 'bar', method: 'GET' })
+            assert.deepEqual(traces, { baz: 1 })
+            return (stopLabels, traces) => {
+              stopTimerCalled = true
+              assert.deepEqual(stopLabels, { bar: false, status: 200, statusGroup: '2xx' })
+              assert.deepEqual(traces, { baz: 1 })
+            }
+          }
+        },
+        fetch: () => Promise.resolve(new Response({ message: 'Success' }, { status: 200 })),
+        startLabelsFrom: () => ({ foo: 'bar' }),
+        tracesFrom: () => ({ baz: 1 }),
+        stopLabelsFrom: () => ({ bar: false })
+      })
+
+      await metricsFunction('someUrl')
+
+      assert.equal(startTimerCalled, true)
+      assert.equal(stopTimerCalled, true)
+    })
+
+    test('when the original function rejects', async () => {
+      let startTimerCalled = false
+      let stopTimerCalled = false
+      let stopLabels = {}
+      let stopTraces = {}
+      const metricsFunction = withTimerMetricsFetch({
+        timer: {
+          startTimer (startLabels, traces) {
+            startTimerCalled = true
+            assert.deepEqual(startLabels, { foo: 'bar', method: 'GET' })
+            assert.deepEqual(traces, { baz: 1 })
+            return (returnedStopLabels, traces) => {
+              stopTimerCalled = true
+              stopLabels = returnedStopLabels
+              stopTraces = traces
+            }
+          }
+        },
+        fetch: () => Promise.reject(new DOMException('I am an error', 'ThisIsAStubbedError')),
+        startLabelsFrom: () => ({ foo: 'bar' }),
+        tracesFrom: () => ({ baz: 1 }),
+        stopLabelsFrom: () => ({ bar: false })
+      })
+
+      await metricsFunction('some url')
+        .then(() => assert.fail('should not resolve the original function'))
+        .catch((err) => {
+          assert.equal(err.message, 'I am an error')
+        })
+
+      assert.equal(startTimerCalled, true)
+      assert.equal(stopTimerCalled, true)
+      assert.deepEqual(stopLabels, { bar: false, errorType: 'ThisIsAStubbedError' })
+      assert.deepEqual(stopTraces, { baz: 1 })
+    })
+  })
+})

--- a/servers/mu/src/domain/lib/with-timer-metrics.js
+++ b/servers/mu/src/domain/lib/with-timer-metrics.js
@@ -1,0 +1,37 @@
+import { always } from 'ramda'
+import { swallow } from '../utils.js'
+
+/**
+ * withTimerMetrics timer only needs to implement a function called 'startTimer' that returns a function to be invoked to stop the timer.
+ * some implementations such as prometheus's histogram have additional constraints such as the labels returned from 'startLabelsFrom' and 'stopLabelsFrom'
+ * need to be referenced as labels passed to the histogram itself. Any additional checks in this way are up to the implementation and are details of the specific implementation.
+ */
+export function withTimerMetrics ({ timer, startLabelsFrom = always({}), stopLabelsFrom = always({}), tracesFrom = always({}), logger = console.warn.bind(console) } = {}) {
+  return (func) => (...funcArgs) => {
+    const startLabels = startLabelsFrom(...funcArgs)
+    const traces = tracesFrom(...funcArgs)
+    const stop = timer.startTimer(startLabels, traces)
+
+    const safeStop = swallow((...args) => {
+      try {
+        return stop(...args)
+      } catch (e) {
+        logger('METRICS ERROR: Error encountered when stopping timer, skipping metric observance.', e)
+        throw e
+      }
+    })
+
+    return Promise.resolve()
+      .then(() => func(...funcArgs))
+      .then((funcReturn) => {
+        safeStop(stopLabelsFrom(funcReturn), traces)
+
+        return funcReturn
+      })
+      .catch((funcReturn) => {
+        safeStop(stopLabelsFrom(funcReturn), traces)
+
+        throw funcReturn
+      })
+  }
+}

--- a/servers/mu/src/domain/lib/with-timer-metrics.test.js
+++ b/servers/mu/src/domain/lib/with-timer-metrics.test.js
@@ -1,0 +1,76 @@
+import { describe, test } from 'node:test'
+import { withTimerMetrics } from './with-timer-metrics.js'
+import assert from 'node:assert'
+
+describe('withTimerMetrics', () => {
+  test('should return the original function result', async () => {
+    const metricsFunction = withTimerMetrics({
+      timer: {
+        startTimer () {
+          return () => {}
+        }
+      }
+    })(() => 'hello world')
+    const functionResult = await metricsFunction()
+    assert.equal(functionResult, 'hello world')
+  })
+
+  describe('should start and stop the timer with expected labels and traces', () => {
+    test('when the original function is successful', async () => {
+      let startTimerCalled = false
+      let stopTimerCalled = false
+      const metricsFunction = withTimerMetrics({
+        timer: {
+          startTimer (startLabels, traces) {
+            startTimerCalled = true
+            assert.deepEqual(startLabels, { foo: 'bar' })
+            assert.deepEqual(traces, { baz: 1 })
+            return (stopLabels, traces) => {
+              stopTimerCalled = true
+              assert.deepEqual(stopLabels, { bar: false })
+              assert.deepEqual(traces, { baz: 1 })
+            }
+          }
+        },
+        startLabelsFrom: () => ({ foo: 'bar' }),
+        tracesFrom: () => ({ baz: 1 }),
+        stopLabelsFrom: () => ({ bar: false })
+      })(() => Promise.resolve('hello world'))
+
+      await metricsFunction()
+
+      assert.equal(startTimerCalled, true)
+      assert.equal(stopTimerCalled, true)
+    })
+
+    test('when the original function rejects', async () => {
+      let startTimerCalled = false
+      let stopTimerCalled = false
+      const metricsFunction = withTimerMetrics({
+        timer: {
+          startTimer (startLabels, traces) {
+            startTimerCalled = true
+            assert.deepEqual(startLabels, { foo: 'bar' })
+            assert.deepEqual(traces, { baz: 1 })
+            return (stopLabels, traces) => {
+              stopTimerCalled = true
+              assert.deepEqual(stopLabels, { bar: false })
+              assert.deepEqual(traces, { baz: 1 })
+            }
+          }
+        },
+        startLabelsFrom: () => ({ foo: 'bar' }),
+        tracesFrom: () => ({ baz: 1 }),
+        stopLabelsFrom: () => ({ bar: false })
+        // eslint-disable-next-line prefer-promise-reject-errors
+      })(() => Promise.reject('I am an error'))
+
+      await metricsFunction()
+        .then(() => assert.fail('should not resolve the original function'))
+        .catch((err) => assert.equal(err, 'I am an error'))
+
+      assert.equal(startTimerCalled, true)
+      assert.equal(stopTimerCalled, true)
+    })
+  })
+})

--- a/servers/mu/src/domain/utils.js
+++ b/servers/mu/src/domain/utils.js
@@ -199,3 +199,33 @@ export const okRes = (res) => {
   if (res.ok) return res
   throw res
 }
+
+// from https://github.com/then/is-promise/blob/master/index.js
+export function isPromise (obj) {
+  return (
+    !!obj &&
+    (typeof obj === 'object' || typeof obj === 'function') &&
+    typeof obj.then === 'function'
+  )
+}
+
+/**
+ * Given a function, it will return a function that swallows any errors. If an error is encountered,
+ * undefined is returned, otherwise the result of the function is returned.
+ *
+ * In other words, a function wrapped with swallow will never throw an error.
+ *
+ * @param {Function} fn - The function to be wrapped.
+ * @returns {Function} A new function that wraps the original function in a try-catch block.
+ *
+ * @example
+ * const safeFunction = swallow(riskyFunction);
+ * safeFunction(args); // Executes riskyFunction with args, but swallows any errors.
+ */
+export const swallow = (fn) => (...args) => {
+  try {
+    const res = fn(...args)
+    if (isPromise(res)) return res.catch(() => {})
+    return res
+  } catch {}
+}

--- a/servers/mu/src/domain/utils.test.js
+++ b/servers/mu/src/domain/utils.test.js
@@ -3,7 +3,7 @@ import * as assert from 'node:assert'
 
 import { z } from 'zod'
 
-import { errFrom, removeTagsByNameMaybeValue } from './utils.js'
+import { errFrom, removeTagsByNameMaybeValue, swallow } from './utils.js'
 
 describe('utils', () => {
   describe('errFrom', () => {
@@ -82,6 +82,37 @@ describe('utils', () => {
           { name: 'SDK', value: 'aoconnect' }
         ]
       )
+    })
+  })
+
+  describe('swallow', () => {
+    test('should resolve the original promise', async () => {
+      const safeFunction = swallow(() => Promise.resolve('hello world'))
+      const result = await safeFunction()
+
+      assert.strictEqual(result, 'hello world')
+    })
+
+    test('should resolve undefined for a rejected promise', async () => {
+      const safeFunction = swallow(() => Promise.reject(new Error('This error should be swallowed')))
+      const result = await safeFunction()
+
+      assert.strictEqual(result, undefined)
+    })
+
+    test('should return the result of the function', () => {
+      const safeFunction = swallow(() => 'hello world')
+
+      const result = safeFunction()
+      assert.equal(result, 'hello world')
+    })
+
+    test('should return undefined for a thrown error', () => {
+      const safeFunction = swallow(() => { throw new Error('This error should be swallowed') })
+
+      const result = safeFunction()
+
+      assert.strictEqual(result, undefined)
     })
   })
 })

--- a/servers/mu/src/domain/utils.test.js
+++ b/servers/mu/src/domain/utils.test.js
@@ -102,14 +102,13 @@ describe('utils', () => {
 
     test('should return the result of the function', () => {
       const safeFunction = swallow(() => 'hello world')
-
       const result = safeFunction()
+
       assert.equal(result, 'hello world')
     })
 
     test('should return undefined for a thrown error', () => {
       const safeFunction = swallow(() => { throw new Error('This error should be swallowed') })
-
       const result = safeFunction()
 
       assert.strictEqual(result, undefined)


### PR DESCRIPTION
closes #826

This adds a new util for swallowing errors as well as a withTimingMetrics HOF that can be used to wrap and compose functions that can keep track of execution time from the start to the return of the function.