### PR TITLE
feat(mu): assign process if spawned with target tag #731

### DIFF
--- a/servers/mu/src/domain/api/sendDataItem.test.js
+++ b/servers/mu/src/domain/api/sendDataItem.test.js
@@ -1,0 +1,102 @@
+import { describe, test } from 'node:test'
+import * as assert from 'node:assert'
+
+import { createLogger } from '../logger.js'
+import { sendDataItemWith } from './sendDataItem.js'
+
+const logger = createLogger('ao-mu:sendDataItem')
+
+describe('sendDataItemWith', () => {
+  describe('Send Data Item', () => {
+    describe('Send process', () => {
+      test('Send process without target for assignment', async () => {
+        let cranked = false
+        const sendDataItem = sendDataItemWith({
+          selectNode: () => 'cu-url',
+          createDataItem: (raw) => ({
+            id: 'process-id',
+            tags: [
+              { name: 'Data-Protocol', value: 'ao' },
+              { name: 'Type', value: 'Process' },
+              { name: 'Scheduler', value: 'scheduler-id' }
+            ]
+          }),
+          writeDataItem: async (res) => ({
+            ...res,
+            id: 'scheduler-id',
+            timestamp: 1234
+          }),
+          locateScheduler: async () => ({ url: 'url-123' }),
+          locateProcess: (res) => res,
+          fetchResult: (res) => res,
+          crank: () => {
+            cranked = true
+          },
+          logger,
+          fetchSchedulerProcess: (res) => res,
+          writeDataItemArweave: (res) => res
+        })
+
+        const { crank, ...result } = await sendDataItem({
+          raw: '1234',
+          tx: { id: 'process-id' }
+        }).toPromise()
+
+        assert.equal(result.schedulerTx.id, 'scheduler-id')
+        assert.equal(result.schedulerTx.suUrl, 'url-123')
+        // TODO: Why is this erroring?
+        try {
+          await crank().toPromise()
+        } catch (_e) {}
+
+        assert.ok(!cranked)
+      })
+
+      test('Send process with target for assignment', async () => {
+        let cranked = false
+        const sendDataItem = sendDataItemWith({
+          selectNode: () => 'cu-url',
+          createDataItem: (raw) => ({
+            id: 'process-id',
+            tags: [
+              { name: 'Target', value: 'target-process-id' },
+              { name: 'Data-Protocol', value: 'ao' },
+              { name: 'Type', value: 'Process' },
+              { name: 'Scheduler', value: 'scheduler-id' }
+            ]
+          }),
+          writeDataItem: async (res) => ({
+            ...res,
+            id: 'scheduler-id',
+            timestamp: 1234
+          }),
+          locateScheduler: async () => ({ url: 'url-123' }),
+          locateProcess: (res) => res,
+          fetchResult: (res) => res,
+          crank: ({ assigns, initialTxId }) => {
+            cranked = true
+            assert.deepStrictEqual(assigns, [{ Message: 'process-id', Processes: ['target-process-id'] }])
+            assert.equal(initialTxId, 'process-id')
+          },
+          logger,
+          fetchSchedulerProcess: (res) => res,
+          writeDataItemArweave: (res) => res
+        })
+
+        const { crank, ...result } = await sendDataItem({
+          raw: '1234',
+          tx: { id: 'process-id' }
+        }).toPromise()
+
+        // TODO: Why is this erroring?
+        try {
+          await crank().toPromise()
+        } catch (_e) {}
+
+        assert.ok(cranked)
+        assert.equal(result.schedulerTx.id, 'scheduler-id')
+        assert.equal(result.schedulerTx.suUrl, 'url-123')
+      })
+    })
+  })
+})

--- a/servers/mu/src/domain/api/sendDataItem.test.js
+++ b/servers/mu/src/domain/api/sendDataItem.test.js
@@ -3,6 +3,7 @@ import * as assert from 'node:assert'
 
 import { createLogger } from '../logger.js'
 import { sendDataItemWith } from './sendDataItem.js'
+import { Resolved } from 'hyper-async'
 
 const logger = createLogger('ao-mu:sendDataItem')
 
@@ -31,6 +32,7 @@ describe('sendDataItemWith', () => {
           fetchResult: (res) => res,
           crank: () => {
             cranked = true
+            return Resolved()
           },
           logger,
           fetchSchedulerProcess: (res) => res,
@@ -44,11 +46,8 @@ describe('sendDataItemWith', () => {
 
         assert.equal(result.schedulerTx.id, 'scheduler-id')
         assert.equal(result.schedulerTx.suUrl, 'url-123')
-        // TODO: Why is this erroring?
-        try {
-          await crank().toPromise()
-        } catch (_e) {}
 
+        await crank().toPromise()
         assert.ok(!cranked)
       })
 
@@ -77,6 +76,7 @@ describe('sendDataItemWith', () => {
             cranked = true
             assert.deepStrictEqual(assigns, [{ Message: 'process-id', Processes: ['target-process-id'] }])
             assert.equal(initialTxId, 'process-id')
+            return Resolved()
           },
           logger,
           fetchSchedulerProcess: (res) => res,
@@ -88,10 +88,7 @@ describe('sendDataItemWith', () => {
           tx: { id: 'process-id' }
         }).toPromise()
 
-        // TODO: Why is this erroring?
-        try {
-          await crank().toPromise()
-        } catch (_e) {}
+        await crank().toPromise()
 
         assert.ok(cranked)
         assert.equal(result.schedulerTx.id, 'scheduler-id')


### PR DESCRIPTION
Closes #731 

When spawning a process, we need to crank assignments if it is spawned with Target tags.