### PR TITLE
docs: latest version for the dev-cli

### DIFF
--- a/dev-cli/README.md
+++ b/dev-cli/README.md
@@ -57,6 +57,12 @@ CLI version, simply run:
 curl -L https://arweave.net/{txId} | bash
 ```
 
+To install the latest version of the `ao` CLI, run:
+
+```sh
+curl -L https://install_ao.g8way.io | bash
+```
+
 Then follow the instructions for adding the `ao` binary to your `PATH`. Use
 `ao --help` to confirm the CLI is installed
 


### PR DESCRIPTION
Probably "fixes" https://github.com/permaweb/ao/issues/824 ;) - the mapping in the deno.json does not contain the latest version (at the time of writing - `0.0.59`) of the CLI