### PR TITLE
fix(mu): timer dependency not passed in correctly

### DIFF
--- a/servers/mu/src/domain/clients/cron.js
+++ b/servers/mu/src/domain/clients/cron.js
@@ -65,7 +65,7 @@ function initCronProcsWith ({ PROC_FILE_PATH, startMonitoredProcess }) {
 function startMonitoredProcessWith ({ fetch, histogram, logger, CRON_CURSOR_DIR, CU_URL, fetchCron, crank, PROC_FILE_PATH }) {
   const getCursorFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'getCursor'
     })

--- a/servers/mu/src/domain/clients/cu.js
+++ b/servers/mu/src/domain/clients/cu.js
@@ -4,7 +4,7 @@ import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
 function resultWith ({ fetch, histogram, CU_URL, logger }) {
   const resultFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'result'
     })
@@ -57,7 +57,7 @@ function selectNodeWith ({ CU_URL, logger }) {
 function fetchCronWith ({ fetch, histogram, CU_URL, logger }) {
   const cronFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'fetchCron'
     })

--- a/servers/mu/src/domain/clients/gateway.js
+++ b/servers/mu/src/domain/clients/gateway.js
@@ -11,7 +11,7 @@ function isWalletWith ({
 }) {
   const walletFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'isWallet'
     })

--- a/servers/mu/src/domain/clients/scheduler.js
+++ b/servers/mu/src/domain/clients/scheduler.js
@@ -6,14 +6,14 @@ import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
 function writeDataItemWith ({ fetch, histogram, logger }) {
   const suFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'writeDataItem'
     })
   })
   const suRedirectFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'writeDataItemWithRedirect'
     })
@@ -71,14 +71,14 @@ function writeDataItemWith ({ fetch, histogram, logger }) {
 function writeAssignmentWith ({ fetch, histogram, logger }) {
   const suFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'writeAssignment'
     })
   })
   const suRedirectFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'writeAssignmentWithRedirect'
     })
@@ -160,7 +160,7 @@ function fetchSchedulerProcessWith ({
 }) {
   const suFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'writeAssignmentWithRedirect'
     })

--- a/servers/mu/src/domain/clients/uploader.js
+++ b/servers/mu/src/domain/clients/uploader.js
@@ -5,7 +5,7 @@ import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
 function uploadDataItemWith ({ UPLOADER_URL, fetch, histogram, logger }) {
   const dataItemFetch = withTimerMetricsFetch({
     fetch,
-    histogram,
+    timer: histogram,
     startLabelsFrom: () => ({
       operation: 'uploadDataItem'
     })


### PR DESCRIPTION
the histogram needs to get passed in as timer since it could be a histogram or summary or any other function that has a `startTimer` prop that returns a stop function.