### PR TITLE
fix: In the event of having no authorities on the list, trust no-one.

### DIFF
--- a/dev-cli/container/src/ao.lua
+++ b/dev-cli/container/src/ao.lua
@@ -175,9 +175,9 @@ function ao.assign(assignment)
     table.insert(ao.outbox.Assignments, assignment)
 end
 
+-- The default security model of AOS processes: Trust all and *only* those
+-- on the ao.authorities list.
 function ao.isTrusted(msg)
-    if #ao.authorities == 0 then return true end
-
     for _, authority in ipairs(ao.authorities) do
         if msg.From == authority then return true end
         if msg.Owner == authority then return true end


### PR DESCRIPTION
While the default AOS behavior is now to add an authority explicitly while starting a process, there is still never a reason to make processes trust everyone in absence of an authority.

For all functional purposes, a process may as well be 'dead' than open for all to access. At some point perhaps a warning/confirmation method should be implemented if the user removes the last authority? But this should be carefully thought through.

For now, this code pattern is already being accidentally copied into other implementations (see the recent cpp dev-cli library), so let's remove the potential for danger from the 'reference' implementation.