### PR TITLE
fix(mu): add error assertion for missing metrics dependency

### DIFF
--- a/servers/mu/src/domain/lib/with-timer-metrics.js
+++ b/servers/mu/src/domain/lib/with-timer-metrics.js
@@ -7,6 +7,9 @@ import { swallow } from '../utils.js'
  * need to be referenced as labels passed to the histogram itself. Any additional checks in this way are up to the implementation and are details of the specific implementation.
  */
 export function withTimerMetrics ({ timer, startLabelsFrom = always({}), stopLabelsFrom = always({}), tracesFrom = always({}), logger = console.warn.bind(console) } = {}) {
+  if (!timer || !timer.startTimer || typeof timer.startTimer !== 'function') {
+    throw new Error('Timer must implement a startTimer function')
+  }
   return (func) => (...funcArgs) => {
     const startLabels = startLabelsFrom(...funcArgs)
     const traces = tracesFrom(...funcArgs)

--- a/servers/mu/src/domain/lib/with-timer-metrics.test.js
+++ b/servers/mu/src/domain/lib/with-timer-metrics.test.js
@@ -3,6 +3,23 @@ import { withTimerMetrics } from './with-timer-metrics.js'
 import assert from 'node:assert'
 
 describe('withTimerMetrics', () => {
+  test('should throw an error if the timer dependency is invalid', () => {
+    assert.throws(() => withTimerMetrics({ timer: {} }), {
+      name: 'Error',
+      message: 'Timer must implement a startTimer function'
+    }, 'Timer must implement a startTimer function')
+
+    assert.throws(() => withTimerMetrics({ timer: { startTimer: 'not a function' } }), {
+      name: 'Error',
+      message: 'Timer must implement a startTimer function'
+    }, 'Timer startTimer property must be a function')
+
+    assert.throws(() => withTimerMetrics({}), {
+      name: 'Error',
+      message: 'Timer must implement a startTimer function'
+    }, 'Timer dependency is required')
+  })
+
   test('should return the original function result', async () => {
     const metricsFunction = withTimerMetrics({
       timer: {


### PR DESCRIPTION
This PR adds an early error check for the timer not being passed in or passed incorrectly for the metrics timer implementation. This will allow for an early signal on server startup if there is a timer metrics use case somewhere that a timer did not get injected into correctly.