### PR TITLE
feat(cu): derive address from owner

### DIFF
--- a/servers/cu/package-lock.json
+++ b/servers/cu/package-lock.json
@@ -24,6 +24,7 @@
         "fastify": "^4.28.1",
         "helmet": "^7.1.0",
         "hyper-async": "^1.1.2",
+        "keccak": "^3.0.4",
         "long-timeout": "^0.1.1",
         "lru-cache": "^10.3.0",
         "ms": "^2.1.3",
@@ -910,6 +911,35 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "node_modules/keccak": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/keccak/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/light-my-request": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.11.0.tgz",
@@ -1019,6 +1049,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemon": {
@@ -2472,6 +2519,28 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "keccak": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "light-my-request": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.11.0.tgz",
@@ -2559,6 +2628,16 @@
       "requires": {
         "semver": "^7.3.5"
       }
+    },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-gyp-build": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw=="
     },
     "nodemon": {
       "version": "3.1.4",

--- a/servers/cu/package.json
+++ b/servers/cu/package.json
@@ -27,6 +27,7 @@
     "fastify": "^4.28.1",
     "helmet": "^7.1.0",
     "hyper-async": "^1.1.2",
+    "keccak": "^3.0.4",
     "long-timeout": "^0.1.1",
     "lru-cache": "^10.3.0",
     "ms": "^2.1.3",

--- a/servers/cu/src/domain/client/ao-process.js
+++ b/servers/cu/src/domain/client/ao-process.js
@@ -9,7 +9,7 @@ import { z } from 'zod'
 import { LRUCache } from 'lru-cache'
 import AsyncLock from 'async-lock'
 
-import { isEarlierThan, isEqualTo, isLaterThan, maybeParseInt, parseTags } from '../utils.js'
+import { isEarlierThan, isEqualTo, isJsonString, isLaterThan, maybeParseInt, parseTags } from '../utils.js'
 import { processSchema } from '../model.js'
 import { PROCESSES_TABLE, CHECKPOINTS_TABLE, COLLATION_SEQUENCE_MIN_CHAR } from './sqlite.js'
 import { timer } from './metrics.js'
@@ -353,9 +353,30 @@ export function findProcessWith ({ db }) {
     .map(defaultTo([]))
     .map(head)
     .chain((row) => row ? Resolved(row) : Rejected({ status: 404, message: 'Process not found' }))
+    .chain((row) => {
+      if (isJsonString(row.owner)) return Resolved(row)
+
+      /**
+       * owner contains the deprecated, pre-parsed value, so we need to self cleanup.
+       * So implictly delete the defunct record and Reject as if it was not found.
+       *
+       * It will then be up the client (in this case the business logic) to re-insert
+       * the record with the proper format
+       */
+      return of({
+        sql: `
+          DELETE FROM ${PROCESSES_TABLE}
+          WHERE
+            id = ?;
+        `,
+        parameters: [processId]
+      }).chain(fromPromise((query) => db.run(query)))
+        .chain(() => Rejected({ status: 404, message: 'Process record invalid' }))
+    })
     .map(evolve({
       tags: JSON.parse,
-      block: JSON.parse
+      block: JSON.parse,
+      owner: JSON.parse
     }))
     .map(processDocSchema.parse)
     .map(applySpec({
@@ -383,7 +404,7 @@ export function saveProcessWith ({ db }) {
         process.signature,
         process.data,
         process.anchor,
-        process.owner,
+        JSON.stringify(process.owner),
         JSON.stringify(process.tags),
         JSON.stringify(process.block)
       ]
@@ -403,6 +424,24 @@ export function saveProcessWith ({ db }) {
       )
       .toPromise()
   }
+}
+
+export function deleteProcessWith ({ db }) {
+  function createQuery ({ processId }) {
+    return {
+      sql: `
+        DELETE FROM ${PROCESSES_TABLE}
+        WHERE
+          id = ?;
+      `,
+      parameters: [processId]
+    }
+  }
+  return ({ processId }) => of({ processId })
+    .map(createQuery)
+    .chain(fromPromise((query) => db.run(query)))
+    .map(always(processId))
+    .toPromise()
 }
 
 /**

--- a/servers/cu/src/domain/client/ao-su.js
+++ b/servers/cu/src/domain/client/ao-su.js
@@ -282,7 +282,7 @@ export const loadProcessWith = ({ fetch, logger }) => {
       })
       .then(resToJson)
       .then(applySpec({
-        owner: (res) => addressFrom(res.owner),
+        owner: path(['owner']),
         tags: path(['tags']),
         block: applySpec({
           height: pipe(

--- a/servers/cu/src/domain/client/ao-su.js
+++ b/servers/cu/src/domain/client/ao-su.js
@@ -4,7 +4,7 @@ import { of } from 'hyper-async'
 import { always, applySpec, filter, has, ifElse, isNil, isNotNil, juxt, last, mergeAll, path, pathOr, pipe, prop } from 'ramda'
 import DataLoader from 'dataloader'
 
-import { backoff, mapForwardedBy, mapFrom, parseTags, strFromFetchError } from '../utils.js'
+import { backoff, mapForwardedBy, mapFrom, addressFrom, parseTags, strFromFetchError } from '../utils.js'
 
 const okRes = (res) => {
   if (res.ok) return res
@@ -56,24 +56,26 @@ export const mapNode = pipe(
     // fromMessage
     pipe(
       path(['message']),
-      ifElse(
-        isNil,
+      (message) => {
         /**
          * No message, meaning this is an Assignment for an existing message
          * on chain, to be hydrated later (see hydrateMessages)
          */
-        always(undefined),
-        applySpec({
+        if (isNil(message)) return undefined
+
+        const address = addressFrom(message.owner)
+
+        return applySpec({
           Id: path(['id']),
           Signature: path(['signature']),
           Data: path(['data']),
-          Owner: path(['owner', 'address']),
+          Owner: always(address),
           Anchor: path(['anchor']),
-          From: (message) => mapFrom({ tags: message.tags, owner: message.owner.address }),
-          'Forwarded-By': (message) => mapForwardedBy({ tags: message.tags, owner: message.owner.address }),
+          From: (message) => mapFrom({ tags: message.tags, owner: address }),
+          'Forwarded-By': (message) => mapForwardedBy({ tags: message.tags, owner: address }),
           Tags: pathOr([], ['tags'])
-        })
-      )
+        })(message)
+      }
     ),
     // both
     applySpec({
@@ -280,7 +282,7 @@ export const loadProcessWith = ({ fetch, logger }) => {
       })
       .then(resToJson)
       .then(applySpec({
-        owner: path(['owner', 'address']),
+        owner: (res) => addressFrom(res.owner),
         tags: path(['tags']),
         block: applySpec({
           height: pipe(

--- a/servers/cu/src/domain/client/ao-su.test.js
+++ b/servers/cu/src/domain/client/ao-su.test.js
@@ -72,6 +72,7 @@ describe('ao-su', () => {
           data: 'su-data-123'
         }
       })
+
       assert.deepStrictEqual(
         withoutAoGlobal.parse(res),
         withoutAoGlobal.parse(expected)

--- a/servers/cu/src/domain/client/arweave.js
+++ b/servers/cu/src/domain/client/arweave.js
@@ -68,6 +68,7 @@ export function loadTransactionMetaWith ({ fetch, GRAPHQL_URL, logger }) {
             anchor @skip (if: $skipAnchor)
             owner {
               address
+              key
             }
             tags @skip (if: $skipTags) {
               name

--- a/servers/cu/src/domain/client/arweave.test.js
+++ b/servers/cu/src/domain/client/arweave.test.js
@@ -57,7 +57,7 @@ describe('arweave', () => {
                   edges: [
                     {
                       node: {
-                        owner: { address: 'owner-123' },
+                        owner: { address: 'owner-123', key: 'key-123' },
                         tags: [
                           {
                             name: 'App-Name',

--- a/servers/cu/src/domain/dal.js
+++ b/servers/cu/src/domain/dal.js
@@ -11,7 +11,8 @@ export const loadTransactionMetaSchema = z.function()
   .returns(z.promise(
     z.object({
       owner: z.object({
-        address: z.string()
+        address: z.string(),
+        key: z.string()
       }),
       tags: z.array(rawTagSchema).default([])
     }).passthrough()

--- a/servers/cu/src/domain/lib/hydrateMessages.js
+++ b/servers/cu/src/domain/lib/hydrateMessages.js
@@ -7,7 +7,7 @@ import WarpArBundles from 'warp-arbundles'
 
 import { loadTransactionDataSchema, loadTransactionMetaSchema } from '../dal.js'
 import { messageSchema, streamSchema } from '../model.js'
-import { mapFrom } from '../utils.js'
+import { mapFrom, addressFrom } from '../utils.js'
 
 const { createData } = WarpArBundles
 
@@ -61,16 +61,20 @@ function loadFromChainWith ({ loadTransactionData, loadTransactionMeta }) {
        * raw transaction data, and metadata about the
        * transactions (in the shape of a GQL Gateway Transaction)
        */
-      .then(async ([meta, Data]) => ({
-        Id: meta.id,
-        Signature: meta.signature,
-        Owner: meta.owner.address,
-        From: mapFrom({ tags: meta.tags, owner: meta.owner.address }),
-        Target: meta.recipient || '',
-        Tags: meta.tags,
-        Anchor: meta.anchor,
-        Data
-      }))
+      .then(async ([meta, Data]) => {
+        const address = addressFrom(meta.owner)
+
+        return {
+          Id: meta.id,
+          Signature: meta.signature,
+          Owner: address,
+          From: mapFrom({ tags: meta.tags, owner: address }),
+          Target: meta.recipient || '',
+          Tags: meta.tags,
+          Anchor: meta.anchor,
+          Data
+        }
+      })
   }
 }
 

--- a/servers/cu/src/domain/lib/hydrateMessages.test.js
+++ b/servers/cu/src/domain/lib/hydrateMessages.test.js
@@ -171,7 +171,8 @@ describe('hydrateMessages', () => {
             signature: 'sig-123',
             anchor: 'anchor-123',
             owner: {
-              address: 'owner-123'
+              address: 'owner-123',
+              key: 'key-123'
             },
             tags: [
               { name: 'foo', value: 'bar' }
@@ -190,7 +191,8 @@ describe('hydrateMessages', () => {
           return {
             id,
             owner: {
-              address: 'owner-123'
+              address: 'owner-123',
+              key: 'key-123'
             },
             // recipient could be an empty string
             recipient: ''
@@ -207,7 +209,8 @@ describe('hydrateMessages', () => {
             signature: 'sig-123',
             anchor: 'anchor-123',
             owner: {
-              address: 'owner-123'
+              address: 'owner-123',
+              key: 'key-123'
             },
             // Not possible with graphql client impl, but still need to test '' default
             recipient: undefined

--- a/servers/cu/src/domain/lib/loadMessageMeta.test.js
+++ b/servers/cu/src/domain/lib/loadMessageMeta.test.js
@@ -38,7 +38,7 @@ describe('loadMessageMeta', () => {
     const loadMessageMeta = loadMessageMetaWith({
       findProcess: async () => ({
         id: 'process-123',
-        owner: 'woohoo',
+        owner: { address: 'woohoo', key: 'key-123' },
         signature: 'sig-123',
         anchor: null,
         data: 'data-123',

--- a/servers/cu/src/domain/lib/loadModule.js
+++ b/servers/cu/src/domain/lib/loadModule.js
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import bytes from 'bytes'
 
 import { findModuleSchema, loadTransactionMetaSchema, saveModuleSchema } from '../dal.js'
-import { parseTags } from '../utils.js'
+import { addressFrom, parseTags } from '../utils.js'
 import { rawTagSchema } from '../model.js'
 
 /**
@@ -49,7 +49,7 @@ function getModuleWith ({ findModule, saveModule, loadTransactionMeta, logger })
       .map((meta) => ({
         id: moduleId,
         tags: meta.tags,
-        owner: meta.owner.address
+        owner: meta.owner
       }))
       .chain((module) =>
         saveModule(module)
@@ -82,7 +82,7 @@ function getModuleWith ({ findModule, saveModule, loadTransactionMeta, logger })
         of(moduleId)
           .chain(maybeFindModule)
           .bichain(loadFromGateway, Resolved)
-          .map((module) => ({ moduleId: module.id, moduleTags: module.tags, moduleOwner: module.owner }))
+          .map((module) => ({ moduleId: module.id, moduleTags: module.tags, moduleOwner: addressFrom(module.owner) }))
           .map(mergeRight(ctx))
       )
   }

--- a/servers/cu/src/domain/lib/loadModule.test.js
+++ b/servers/cu/src/domain/lib/loadModule.test.js
@@ -11,6 +11,10 @@ const PROCESS = 'contract-123-9HdeqeuYQOgMgWucro'
 const logger = createLogger('ao-cu:readState')
 
 describe('loadModule', () => {
+  const moduleOwner = {
+    address: 'owner-123',
+    key: 'key-123'
+  }
   const moduleTags = [
     { name: 'Data-Protocol', value: 'ao' },
     { name: 'Type', value: 'Module' },
@@ -24,9 +28,7 @@ describe('loadModule', () => {
   test('append moduleId, moduleOwner, moduleTags, and moduleOptions', async () => {
     const loadModule = loadModuleWith({
       loadTransactionMeta: async () => ({
-        owner: {
-          address: 'owner-123'
-        },
+        owner: moduleOwner,
         tags: moduleTags
       }),
       findModule: async () => { throw { status: 404 } },
@@ -80,9 +82,7 @@ describe('loadModule', () => {
   test('should fallback to Module tags for Compute-Limit and Module-Limit if not on Process', async () => {
     const loadModule = loadModuleWith({
       loadTransactionMeta: async () => ({
-        owner: {
-          address: 'owner-123'
-        },
+        owner: moduleOwner,
         tags: moduleTags
       }),
       findModule: async () => { throw { status: 404 } },
@@ -137,7 +137,7 @@ describe('loadModule', () => {
         return {
           id: 'foobar',
           tags: moduleTags,
-          owner: 'owner-123'
+          owner: moduleOwner
         }
       },
       saveModule: async () => assert.fail('should not save if found in db'),
@@ -189,9 +189,7 @@ describe('loadModule', () => {
     test('a single extension', async () => {
       const loadModule = loadModuleWith({
         loadTransactionMeta: async () => ({
-          owner: {
-            address: 'owner-123'
-          },
+          owner: moduleOwner,
           tags: [
             ...moduleTags,
             { name: 'Extension', value: 'Foo' },
@@ -228,9 +226,7 @@ describe('loadModule', () => {
     test('multiple extensions', async () => {
       const loadModule = loadModuleWith({
         loadTransactionMeta: async () => ({
-          owner: {
-            address: 'owner-123'
-          },
+          owner: moduleOwner,
           tags: [
             ...moduleTags,
             { name: 'Extension', value: 'Foo' },
@@ -275,9 +271,7 @@ describe('loadModule', () => {
   test('throw if "Input-Encoding" is not found', async () => {
     const loadModule = loadModuleWith({
       loadTransactionMeta: async () => ({
-        owner: {
-          address: 'owner-123'
-        },
+        owner: moduleOwner,
         tags: remove(3, 1, moduleTags)
       }),
       findModule: async () => { throw { status: 404 } },
@@ -303,9 +297,7 @@ describe('loadModule', () => {
   test('throw if "Output-Encoding" is not found', async () => {
     const loadModule = loadModuleWith({
       loadTransactionMeta: async () => ({
-        owner: {
-          address: 'owner-123'
-        },
+        owner: moduleOwner,
         tags: remove(4, 1, moduleTags)
       }),
       findModule: async () => { throw { status: 404 } },
@@ -331,9 +323,7 @@ describe('loadModule', () => {
   test('throw if "Module-Format" is not supported', async () => {
     const loadModule = loadModuleWith({
       loadTransactionMeta: async () => ({
-        owner: {
-          address: 'owner-123'
-        },
+        owner: moduleOwner,
         tags: set(
           lensIndex(2),
           { name: 'Module-Format', value: 'wasm64-unknown-emscripten' },
@@ -363,9 +353,7 @@ describe('loadModule', () => {
   test('throw if Module Extension is not supported', async () => {
     const loadModule = loadModuleWith({
       loadTransactionMeta: async () => ({
-        owner: {
-          address: 'owner-123'
-        },
+        owner: moduleOwner,
         tags: [
           ...moduleTags,
           { name: 'Extension', value: 'Foo' },
@@ -402,9 +390,7 @@ describe('loadModule', () => {
     test('throw if not found', async () => {
       const loadModule = loadModuleWith({
         loadTransactionMeta: async () => ({
-          owner: {
-            address: 'owner-123'
-          },
+          owner: moduleOwner,
           tags: remove(5, 1, moduleTags)
         }),
         findModule: async () => { throw { status: 404 } },
@@ -427,9 +413,7 @@ describe('loadModule', () => {
     test('throw if exceeds max allowed', async () => {
       const loadModule = loadModuleWith({
         loadTransactionMeta: async () => ({
-          owner: {
-            address: 'owner-123'
-          },
+          owner: moduleOwner,
           tags: moduleTags
         }),
         findModule: async () => { throw { status: 404 } },
@@ -454,9 +438,7 @@ describe('loadModule', () => {
     test('throw if is not found', async () => {
       const loadModule = loadModuleWith({
         loadTransactionMeta: async () => ({
-          owner: {
-            address: 'owner-123'
-          },
+          owner: moduleOwner,
           tags: remove(6, 1, moduleTags)
         }),
         findModule: async () => { throw { status: 404 } },
@@ -479,9 +461,7 @@ describe('loadModule', () => {
     test('throw if exceeds max allowed', async () => {
       const loadModule = loadModuleWith({
         loadTransactionMeta: async () => ({
-          owner: {
-            address: 'owner-123'
-          },
+          owner: moduleOwner,
           tags: moduleTags
         }),
         findModule: async () => { throw { status: 404 } },

--- a/servers/cu/src/domain/lib/loadProcessMeta.js
+++ b/servers/cu/src/domain/lib/loadProcessMeta.js
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import { findProcessSchema, isProcessOwnerSupportedSchema, loadProcessSchema, locateProcessSchema, saveProcessSchema } from '../dal.js'
 import { blockSchema, rawTagSchema } from '../model.js'
-import { eqOrIncludes, findRawTag, parseTags, trimSlash } from '../utils.js'
+import { eqOrIncludes, findRawTag, parseTags, trimSlash, addressFrom } from '../utils.js'
 
 /**
  * The result that is produced from this step
@@ -143,7 +143,7 @@ function getProcessMetaWith ({ loadProcess, locateProcess, findProcess, saveProc
         signature: process.signature,
         data: process.data,
         anchor: process.anchor,
-        owner: process.owner,
+        owner: addressFrom(process.owner),
         tags: process.tags,
         block: process.block
       }))

--- a/servers/cu/src/domain/lib/loadProcessMeta.test.js
+++ b/servers/cu/src/domain/lib/loadProcessMeta.test.js
@@ -32,7 +32,7 @@ describe('loadProcess', () => {
         assert.equal(processId, PROCESS)
         assert.equal(suUrl, 'https://foo.bar')
         return {
-          owner: 'woohoo',
+          owner: { address: 'woohoo', key: 'key-123' },
           tags,
           signature: 'sig-123',
           anchor: null,
@@ -67,7 +67,7 @@ describe('loadProcess', () => {
       isProcessOwnerSupported: async (process) => true,
       findProcess: async () => ({
         id: PROCESS,
-        owner: 'woohoo',
+        owner: { address: 'woohoo', key: 'key-123' },
         signature: 'sig-123',
         anchor: null,
         data: 'data-123',
@@ -109,7 +109,7 @@ describe('loadProcess', () => {
       saveProcess: async (process) => {
         assert.deepStrictEqual(process, {
           id: PROCESS,
-          owner: 'woohoo',
+          owner: { address: 'woohoo', key: 'key-123' },
           tags,
           block: { height: 123, timestamp: 1697574792000 }
         })
@@ -117,7 +117,7 @@ describe('loadProcess', () => {
       },
       locateProcess: async ({ processId: id }) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
-        owner: 'woohoo',
+        owner: { address: 'woohoo', key: 'key-123' },
         tags,
         block: { height: 123, timestamp: 1697574792000 }
       }),
@@ -140,7 +140,7 @@ describe('loadProcess', () => {
       saveProcess: async () => { throw { status: 409 } },
       locateProcess: async ({ processId: id }) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
-        owner: 'woohoo',
+        owner: { address: 'woohoo', key: 'key-123' },
         tags,
         block: { height: 123, timestamp: 1697574792000 }
       }),
@@ -162,7 +162,7 @@ describe('loadProcess', () => {
       saveProcess: async () => PROCESS,
       locateProcess: async ({ processId: id }) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
-        owner: 'woohoo',
+        owner: { address: 'woohoo', key: 'key-123' },
         tags: [
           { name: 'Not_Module', value: 'foobar' },
           { name: 'Data-Protocol', value: 'ao' },
@@ -185,7 +185,7 @@ describe('loadProcess', () => {
       saveProcess: async () => PROCESS,
       locateProcess: async ({ processId: id }) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
-        owner: 'woohoo',
+        owner: { address: 'woohoo', key: 'key-123' },
         tags: [
           { name: 'Module', value: 'foobar' },
           { name: 'Data-Protocol', value: 'not_ao' },
@@ -208,7 +208,7 @@ describe('loadProcess', () => {
       saveProcess: async () => PROCESS,
       locateProcess: async ({ processId: id }) => ({ url: 'https://foo.bar' }),
       loadProcess: async (id) => ({
-        owner: 'woohoo',
+        owner: { address: 'woohoo', key: 'key-123' },
         tags: [
           { name: 'Module', value: 'foobar' },
           { name: 'Data-Protocol', value: 'ao' },
@@ -236,7 +236,7 @@ describe('loadProcess', () => {
       isProcessOwnerSupported: async (process) => false,
       findProcess: async () => ({
         id: PROCESS,
-        owner: 'woohoo',
+        owner: { address: 'woohoo', key: 'key-123' },
         signature: 'sig-123',
         anchor: null,
         data: 'data-123',

--- a/servers/cu/src/domain/model.js
+++ b/servers/cu/src/domain/model.js
@@ -210,6 +210,11 @@ export const blockSchema = z.object({
   timestamp: z.coerce.number()
 })
 
+export const ownerSchema = z.object({
+  address: z.string(),
+  key: z.string()
+})
+
 export const processSchema = z.object({
   id: z.string().min(1),
   /**
@@ -218,7 +223,7 @@ export const processSchema = z.object({
   signature: z.string().nullish(),
   data: z.any().nullish(),
   anchor: z.string().nullish(),
-  owner: z.string().min(1),
+  owner: ownerSchema,
   tags: z.array(rawTagSchema),
   block: blockSchema
 })
@@ -239,7 +244,7 @@ export const processCheckpointSchema = z.object({
 export const moduleSchema = z.object({
   id: z.string().min(1),
   tags: z.array(rawTagSchema),
-  owner: z.string().min(1)
+  owner: ownerSchema
 })
 
 export const messageSchema = z.object({

--- a/servers/cu/src/domain/utils.js
+++ b/servers/cu/src/domain/utils.js
@@ -433,6 +433,15 @@ export const arrayBufferFromMaybeView = (maybeView) => ArrayBuffer.isView(maybeV
   ? maybeView.buffer
   : maybeView // assumes an ArrayBuffer. TODO: maybe an additional check
 
+export function isJsonString (str) {
+  try {
+    JSON.parse(str)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
 /**
  * #################################
  * #### Signature/Address Utils ####

--- a/servers/cu/src/domain/utils.test.js
+++ b/servers/cu/src/domain/utils.test.js
@@ -12,7 +12,8 @@ import {
   isEarlierThan,
   maybeParseInt,
   isEqualTo,
-  strFromFetchError
+  strFromFetchError,
+  addressFrom
 } from './utils.js'
 
 describe('utils', () => {
@@ -424,6 +425,30 @@ describe('utils', () => {
       assert.equal(await strFromFetchError(new Response('error from native Response', { status: 422 })), '422: error from native Response')
       assert.equal(await strFromFetchError(new UndiciResponse('error from undici Response', { status: 400 })), '400: error from undici Response')
       assert.equal(await strFromFetchError({ status: 404, text: () => 'error from pojo' }), '404: error from pojo')
+    })
+  })
+
+  describe('addressFrom', () => {
+    test('should return the address for arweave public keys', () => {
+      const address = 'ukkobWjvi0Gwt7SSt2pdQRS2vXsRO3s-kGDx7jQlJdY'
+      const key = 'sA3TgZ_yWVqU7wKurqwvV8LWqLHHMFXGPoFRAq-wYqntTl4_BbR7u3EIYiC9xUh1yaveiyquDNub1wp3SN5W8GZSugnu29EyUcPo1eH976hRlthHtJAk4fidbXNgUPHf25qkVAfYcl84S8cKCis8sFTIwxOaKDBnZiTkgYkYNO2_iav82p-N-WQ20oC_QNj9tXkl8vyYqhAKIwBT_Wf1P8CNDQiAFbR4aMK4x1c19RaA0gxUtQrVs3LlVbeygImUXvoKzad1PkGj3bPPXoMe1JzSul9J5VRR1qiOKVBloNCfTFfEykw5BCshWBNgMJ2Vgh_qyrx9nQGXU-dlTcnWISyTrD5Ctm0tqq0lqaLN3lTLIDHUsQdQbkTMaXfxDSym09A-gDb6bmyatwwMMNlKHRy_H6Shp28PrPQJWdducViMdcx0timKFYWMAGBehtFIe2eI7fc7nNmuJ6NxG8MBSt9PoGWxEhktjjAYxhmQOVCaT2aQRmvmWmp2F9XONiGY5Q4jqbwrIG89eVrNJmUBf3oeTCdjMSsqoj8ypr4oWVyOGJkxwn4gmKJ1w9TzcSIN-1bT9T1J6P2lamQYiF9CqGfzQ-Hqa-nBvfhFCaOxX_6JIBcN5ng52w_cTtLT_gs6VI90PZQzDe_HHlepgW_yf85FLlg9hhnU2TmNLkmshRk'
+
+      const res = addressFrom({ address, key })
+      assert.equal(res, address)
+    })
+
+    test('should return the ethereum address for ethereum public keys', () => {
+      const address = 'KNrSdKEQPHc3lHcLUViwvGONLYp2EcxL_oaHBH6zh3w'
+      const keys = ['BEZGrlBHMWtCMNAIbIrOxofwCxzZ0dxjT2yzWKwKmo___ne03QpL-5WFHztzVceB3WD4QY_Ipl0UkHr_R8kDpVk', 'BOaKz8AlOhBiDf9wawobHx9YM-o76zveIlDV8nHzVjYGZy68ReC36i6BbstwygMTexyUdu7GPUYy6ZACC3tvujk']
+
+      const ethAddresses = ['0xFCAd0B19bB29D4674531d6f115237E16AfCE377c', '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1']
+
+      keys.forEach((key, idx) => {
+        const res = addressFrom({ address, key })
+        assert.ok(res)
+        assert.equal(res, ethAddresses[idx])
+        assert.equal(res.length, 42) // last 20 bytes prefixed with '0x'
+      })
     })
   })
 })


### PR DESCRIPTION
Closes #862 

This PR makes it so the CU will now set fields derived from `owner` using a projection of the data, instead of straight mapping `owner.address`. This allows the CU to map `owner` to more idiomatic addresses, given the owner. For example, this PR implements setting fields to an idiomatic Ethereum address if it detects the owner is an Ethereum account

Subsequently, the CU now needs more information to determine the value of fields on `Process`, `Module`, and `Message`, and that information was not being cached on the cached records. So this PR also includes changes such that the mapping of `owner` is performed in business logic, instead of pre-cached, and the cached records will "self-migrate" such that they store the necessary data needed by the CU to perform its derivations.