### PR TITLE
fix(mu): pulling result on a process msg will now have tx id, error handling fixed

### DIFF
--- a/servers/mu/src/domain/lib/build-success-tx.js
+++ b/servers/mu/src/domain/lib/build-success-tx.js
@@ -1,8 +1,8 @@
-import { of, fromPromise } from 'hyper-async'
+import { of, fromPromise, Resolved } from 'hyper-async'
 import z from 'zod'
 import { assoc, __, defaultTo, concat } from 'ramda'
 
-import { removeTagsByNameMaybeValue } from '../utils.js'
+import { checkStage, removeTagsByNameMaybeValue } from '../utils.js'
 
 const ctxSchema = z.object({
   spawnSuccessTx: z.any()
@@ -12,7 +12,8 @@ export function buildSuccessTxWith ({ buildAndSign, logger }) {
   return (ctx) => {
     /**
      * Start with the Tags from the original spawned message
-     */
+    */
+    if (!checkStage('build-success-tx')(ctx)) return Resolved(ctx)
     return of(ctx.cachedSpawn.spawn.Tags)
       .map(defaultTo([]))
       /**


### PR DESCRIPTION
Breaking issue was that tx.id did not exist on context.
Deeper issue was pull-result was not properly bubbling errors. Both fixed.