### PR TITLE
Write test cases for saveCheckpointWith

### DIFF
--- a/servers/cu/src/domain/client/ao-process.js
+++ b/servers/cu/src/domain/client/ao-process.js
@@ -1422,11 +1422,15 @@ export function saveCheckpointWith ({
       }))
       .map(path(['data', 'transactions', 'edges', '0']))
       .chain((checkpoint) => {
-        /**
-         * This CU has already created a Checkpoint
-         * for this evaluation so simply noop
-         */
         if (checkpoint) {
+          if (!Array.isArray(checkpoint.node.tags)) {
+            // TODO: should probably use a Zod schema to verify 'queryCheckpoints' returns the data structure we expect
+            return Rejected('expected checkpoint tags to be an array, cannot use checkpoint found on Arweave')
+          }
+          /**
+           * This CU has already created a Checkpoint
+           * for this evaluation so simply noop
+           */
           return Resolved({ id: checkpoint.node.id, encoding: pluckTagValue('Content-Encoding', checkpoint.node.tags) })
         }
 

--- a/servers/cu/src/domain/client/ao-process.js
+++ b/servers/cu/src/domain/client/ao-process.js
@@ -1217,7 +1217,8 @@ export function saveCheckpointWith ({
   writeCheckpointRecord,
   logger: _logger,
   PROCESS_CHECKPOINT_CREATION_THROTTLE,
-  DISABLE_PROCESS_CHECKPOINT_CREATION
+  DISABLE_PROCESS_CHECKPOINT_CREATION,
+  recentCheckpoints = new Map()
 }) {
   readProcessMemoryFile = fromPromise(readProcessMemoryFile)
   address = fromPromise(address)
@@ -1351,7 +1352,6 @@ export function saveCheckpointWith ({
       .chain(buildAndSignDataItem)
   }
 
-  const recentCheckpoints = new Map()
   const addRecentCheckpoint = (processId) => {
     /**
      * Shouldn't happen, since the entries clear themselves when their ttl


### PR DESCRIPTION
closes #804 

Adds a number of test cases to test each branch as well as the "happy path"

Adjusts the internal `recentCheckpoints` to be a dependency that defaults to a `new Map()`

Add a conditional check to verify that the Data Item has a tags array