### PR TITLE
chore(cu): add backoff, circuit breaker to gatweay client for load block metadata

### DIFF
--- a/servers/cu/package-lock.json
+++ b/servers/cu/package-lock.json
@@ -27,6 +27,7 @@
         "long-timeout": "^0.1.1",
         "lru-cache": "^10.3.0",
         "ms": "^2.1.3",
+        "opossum": "^8.1.4",
         "p-map": "^7.0.2",
         "prom-client": "^15.1.3",
         "ramda": "^0.30.1",
@@ -1095,6 +1096,14 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opossum": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-8.1.4.tgz",
+      "integrity": "sha512-ktDDCD2MKX7yx8ZLtt57JrUE0IyYJthmTyXtaF4dEdPYHvX0kkWRiKkQkhEjtZnTNN5y1ErMriKNqOLqgpYXtQ==",
+      "engines": {
+        "node": "^22 || ^21 || ^20 || ^18 || ^16"
       }
     },
     "node_modules/p-map": {
@@ -2601,6 +2610,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "opossum": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-8.1.4.tgz",
+      "integrity": "sha512-ktDDCD2MKX7yx8ZLtt57JrUE0IyYJthmTyXtaF4dEdPYHvX0kkWRiKkQkhEjtZnTNN5y1ErMriKNqOLqgpYXtQ=="
     },
     "p-map": {
       "version": "7.0.2",

--- a/servers/cu/package.json
+++ b/servers/cu/package.json
@@ -30,6 +30,7 @@
     "long-timeout": "^0.1.1",
     "lru-cache": "^10.3.0",
     "ms": "^2.1.3",
+    "opossum": "^8.1.4",
     "p-map": "^7.0.2",
     "prom-client": "^15.1.3",
     "ramda": "^0.30.1",


### PR DESCRIPTION
Closes #368 

Adds a backoff and a circuit breaker to load block metadata call. Adds tests to ensure they are working.