### PR TITLE
perf(cu): remove wasm instances from cache on finish #845

### DIFF
--- a/servers/cu/src/domain/lib/evaluate.js
+++ b/servers/cu/src/domain/lib/evaluate.js
@@ -240,7 +240,7 @@ export function evaluateWith (env) {
             ),
             (err) => {
               /**
-               * finshed() will leave dangling event listeners even after this callback
+               * finished() will leave dangling event listeners even after this callback
                * has been invoked, so that unexpected errors do not cause full-on crashes.
                *
                * finished() returns a callback fn to cleanup these dangling listeners, so we make sure
@@ -249,6 +249,13 @@ export function evaluateWith (env) {
                * See https://nodejs.org/api/stream.html#streamfinishedstream-options-callback
                */
               cleanup()
+              if (!err) {
+                /**
+                 * Send a flag to the evaluator that the eval stream is finished.
+                 * This will allow for the WASM instance to be removed from the cache.
+                 */
+                ctx.evaluator({ close: true })
+              }
               err ? reject(err) : resolve()
             }
           )

--- a/servers/cu/src/domain/worker/evaluate.js
+++ b/servers/cu/src/domain/worker/evaluate.js
@@ -158,12 +158,20 @@ export function evaluateWith ({
    *
    * Finally, evaluates the message and returns the result of the evaluation.
    */
-  return ({ streamId, moduleId, wasmModule, moduleOptions, processId, noSave, name, deepHash, cron, ordinate, isAssignment, Memory, message, AoGlobal }) =>
+  return ({ streamId, moduleId, wasmModule, moduleOptions, processId, noSave, name, deepHash, cron, ordinate, isAssignment, Memory, message, AoGlobal, close }) => {
+    /**
+     * If we receive the close flag, it means we have reached the end of the eval stream.
+     * We will remove the WASM instance from the cache and skip loading the module.
+     */
+    if (close) {
+      wasmInstanceCache.delete(streamId)
+      return
+    }
     /**
      * Dynamically load the module, either from cache,
      * or from a file
      */
-    maybeCachedInstance({ streamId, moduleId, wasmModule, moduleOptions, name, processId, Memory, message, AoGlobal })
+    return maybeCachedInstance({ streamId, moduleId, wasmModule, moduleOptions, name, processId, Memory, message, AoGlobal })
       .bichain(loadInstance, Resolved)
       /**
        * Perform the evaluation
@@ -225,4 +233,5 @@ export function evaluateWith ({
           })
       )
       .toPromise()
+  }
 }

--- a/servers/cu/src/domain/worker/evaluate.test.js
+++ b/servers/cu/src/domain/worker/evaluate.test.js
@@ -428,5 +428,34 @@ describe('evaluate', async () => {
         assert.equal(cache.size, 0)
       })
     })
+
+    test('returns nothing, removes from cache if close flag received', async () => {
+      const wasmInstanceCache = new LRUCache({ max: 1 })
+      wasmInstanceCache.set('stream-123', 'foo')
+
+      const evaluate = evaluateWith({
+        saveEvaluation: async (evaluation) => evaluation,
+        wasmInstanceCache,
+        loadWasmModule: () => assert.fail('should not call if close flag received'),
+        bootstrapWasmInstance: () => assert.fail('should not call if close flag received'),
+        ARWEAVE_URL: 'https://foo.bar',
+        logger
+      })
+
+      const args = {
+        streamId: 'stream-123',
+        close: true
+      }
+
+      /**
+       * Should return undefined if close flag is received
+       */
+      const res = await evaluate(args)
+      assert.ok(!res)
+      /**
+       * Should remove stream-123 from cache, leaving size of 0 remaining.
+       */
+      assert.equal(wasmInstanceCache.size, 0)
+    })
   })
 })


### PR DESCRIPTION
Closes #845 

Sends a signal when the eval stream is finished. Delete WASM instance from cache when this flag is received.