### PR TITLE
fix(scheduler-utils): trim trailing slash from returned URLs #246

### DIFF
--- a/scheduler-utils/src/locate.js
+++ b/scheduler-utils/src/locate.js
@@ -1,4 +1,5 @@
 import { checkForRedirectSchema, getByOwnerSchema, getByProcessSchema, loadProcessSchedulerSchema, loadSchedulerSchema, setByOwnerSchema, setByProcessSchema } from './dal.js'
+import { trimSlash } from './utils.js'
 
 export function locateWith ({ loadProcessScheduler, loadScheduler, cache, followRedirects, checkForRedirect }) {
   loadProcessScheduler = loadProcessSchedulerSchema.implement(loadProcessScheduler)
@@ -53,7 +54,7 @@ export function locateWith ({ loadProcessScheduler, loadScheduler, cache, follow
              */
             if (followRedirects) finalUrl = await checkForRedirect(scheduler.url, process)
 
-            const byProcess = { url: finalUrl, address: scheduler.address }
+            const byProcess = { url: trimSlash(finalUrl), address: scheduler.address }
             await setByProcess(process, byProcess, scheduler.ttl)
             return byProcess
           })

--- a/scheduler-utils/src/raw.js
+++ b/scheduler-utils/src/raw.js
@@ -1,5 +1,6 @@
 import { getByOwnerSchema, loadSchedulerSchema, setByOwnerSchema } from './dal.js'
 import { InvalidSchedulerLocationError } from './err.js'
+import { trimSlash } from './utils.js'
 
 export function rawWith ({ loadScheduler, cache }) {
   loadScheduler = loadSchedulerSchema.implement(loadScheduler)
@@ -19,7 +20,7 @@ export function rawWith ({ loadScheduler, cache }) {
         return loadScheduler(address)
           .then((scheduler) =>
             setByOwner(address, scheduler.url, scheduler.ttl)
-              .then(() => ({ url: scheduler.url }))
+              .then(() => ({ url: trimSlash(scheduler.url) }))
           )
           .catch((err) => {
             if (err instanceof InvalidSchedulerLocationError) return undefined

--- a/scheduler-utils/src/utils.js
+++ b/scheduler-utils/src/utils.js
@@ -1,0 +1,4 @@
+export function trimSlash (str = '') {
+  str = str.trim()
+  return str.endsWith('/') ? trimSlash(str.slice(0, -1)) : str
+}

--- a/scheduler-utils/src/utils.test.js
+++ b/scheduler-utils/src/utils.test.js
@@ -1,0 +1,12 @@
+import { describe, test } from 'node:test'
+import * as assert from 'node:assert'
+import { trimSlash } from './utils.js'
+
+describe('trimSlash', () => {
+  test('should remove trailing slash from url', () => {
+    const resultWithTrailingSlash = trimSlash('https://foo.bar/')
+    assert.equal(resultWithTrailingSlash, 'https://foo.bar')
+    const resultWithoutTrailingSlash = trimSlash('https://foo.bar')
+    assert.equal(resultWithoutTrailingSlash, 'https://foo.bar')
+  })
+})


### PR DESCRIPTION
closes #246 

adds a `trimTrailingSlash` function with a test to trim the trailing slash from the URL if it has one.

Wraps the URL returned from both `raw` and `locate` function return values.