### PR TITLE
feat(mu): separate URL configuration

### DIFF
--- a/servers/mu/.env.example
+++ b/servers/mu/.env.example
@@ -1,6 +1,5 @@
 PORT=3004
 CU_URL="https://cu.ao-testnet.xyz"
-GRAPHQL_URL="https://arweave.net/graphql"
 NODE_CONFIG_ENV="development"
 DEBUG=*
 PATH_TO_WALLET="/home/wallet.json"

--- a/servers/mu/README.md
+++ b/servers/mu/README.md
@@ -28,7 +28,16 @@ There are a few environment variables that you can set:
   `http://localhost:6363` in development mode)
 - `PORT`: Which port the web server should listen on (defaults to port `3005`)
 - `ENABLE_METRICS_ENDPOINT`: Whether the OpenTelemetry endpoint `/metrics` should be enabled. Set to any value to enable. (defaults to disabled)
-- `GRAPHQL_URL`: The url for the Arweave Gateway GraphQL server to be used by the MU. (defaults to https://arweave.net/graphql)
+- `GATEWAY_URL`: The url of the Arweave gateway to use. (Defaults to
+  `https://arweave.net`)
+
+> `GATEWAY_URL` is solely used as a fallback for both `ARWEAVE_URL` and
+> `GRAPHQL_URL`, if not provided (see below).
+
+- `ARWEAVE_URL`: The url for the Arweave http API server, to be used by the CU
+  to fetch transaction data from Arweave, specifically ao `Modules`, and
+  `Message` `Assignment`s. (Defaults to `GATEWAY_URL`)
+- `GRAPHQL_URL`: The url for the Arweave Gateway GraphQL server to be used by the MU. (Defaults to `${GATEWAY_URL}/graphql`)
 - `PATH_TO_WALLET`: the path to the wallet JWK interface you would like the `mu`
   to use to sign messages that it is pushing
 - `DEBUG`: if DEBUG=* or DEBUG=ao-mu* then verbose debug logs will be provided in the console.

--- a/servers/mu/src/domain/clients/gateway.js
+++ b/servers/mu/src/domain/clients/gateway.js
@@ -1,10 +1,10 @@
-import { backoff, okRes } from '../utils.js'
+import { backoff, joinUrl, okRes } from '../utils.js'
 import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
 
 function isWalletWith ({
   fetch,
   histogram,
-  GRAPHQL_URL,
+  ARWEAVE_URL,
   logger,
   setById,
   getById
@@ -27,7 +27,7 @@ function isWalletWith ({
       return cachedIsWallet.isWallet
     }
 
-    logger(`id: ${id} not cached checking gateway for tx`)
+    logger(`id: ${id} not cached checking arweave for tx`)
 
     /*
       Only if this is actually a tx will this
@@ -36,14 +36,13 @@ function isWalletWith ({
     */
     return backoff(
       () =>
-        walletFetch(`${GRAPHQL_URL.replace('/graphql', '')}/${id}`, {
-          method: 'HEAD'
-        }).then(okRes),
+        walletFetch(joinUrl({ url: ARWEAVE_URL, path: `/${id}` }), { method: 'HEAD' })
+          .then(okRes),
       {
         maxRetries: 3,
         delay: 500,
         log: logger,
-        name: `isWalletOnGateway(${id})`
+        name: `isWallet(${id})`
       }
     )
       .then((res) => {

--- a/servers/mu/src/domain/index.js
+++ b/servers/mu/src/domain/index.js
@@ -60,6 +60,8 @@ const cronMonitorGauge = MetricsClient.gaugeWith({})({
 export const createApis = async (ctx) => {
   const CU_URL = ctx.CU_URL
   const UPLOADER_URL = ctx.UPLOADER_URL
+  const GRAPHQL_URL = ctx.GRAPHQL_URL
+  const ARWEAVE_URL = ctx.ARWEAVE_URL
   const PROC_FILE_PATH = ctx.PROC_FILE_PATH
   const CRON_CURSOR_DIR = ctx.CRON_CURSOR_DIR
 
@@ -72,7 +74,7 @@ export const createApis = async (ctx) => {
     logger
   })
 
-  const { locate, raw } = schedulerUtilsConnect({ cacheSize: 500, GRAPHQL_URL: ctx.GRAPHQL_URL, followRedirects: true })
+  const { locate, raw } = schedulerUtilsConnect({ cacheSize: 500, GRAPHQL_URL, followRedirects: true })
 
   const cache = InMemoryClient.createLruCache({ size: 500 })
   const getByProcess = InMemoryClient.getByProcessWith({ cache })
@@ -153,7 +155,7 @@ export const createApis = async (ctx) => {
     fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: sendDataItemLogger }),
     fetchSchedulerProcess: schedulerClient.fetchSchedulerProcessWith({ getByProcess, setByProcess, fetch, histogram, logger: sendDataItemLogger }),
     crank,
-    isWallet: gatewayClient.isWalletWith({ fetch, histogram, GRAPHQL_URL: ctx.GRAPHQL_URL, logger: sendDataItemLogger }),
+    isWallet: gatewayClient.isWalletWith({ fetch, histogram, ARWEAVE_URL, logger: sendDataItemLogger }),
     logger: sendDataItemLogger,
     writeDataItemArweave: uploaderClient.uploadDataItemWith({ UPLOADER_URL, logger: sendDataItemLogger, fetch, histogram })
   })
@@ -223,6 +225,8 @@ export const createResultApis = async (ctx) => {
   const CU_URL = ctx.CU_URL
   const MU_WALLET = ctx.MU_WALLET
   const UPLOADER_URL = ctx.UPLOADER_URL
+  const GRAPHQL_URL = ctx.GRAPHQL_URL
+  const ARWEAVE_URL = ctx.ARWEAVE_URL
 
   const logger = ctx.logger
   const fetch = ctx.fetch
@@ -233,8 +237,8 @@ export const createResultApis = async (ctx) => {
     logger
   })
 
-  const { locate, raw } = schedulerUtilsConnect({ cacheSize: 500, GRAPHQL_URL: ctx.GRAPHQL_URL, followRedirects: true })
-  const { locate: locateNoRedirect } = schedulerUtilsConnect({ cacheSize: 500, GRAPHQL_URL: ctx.GRAPHQL_URL, followRedirects: false })
+  const { locate, raw } = schedulerUtilsConnect({ cacheSize: 500, GRAPHQL_URL, followRedirects: true })
+  const { locate: locateNoRedirect } = schedulerUtilsConnect({ cacheSize: 500, GRAPHQL_URL, followRedirects: false })
 
   const cache = InMemoryClient.createLruCache({ size: 500 })
   const getByProcess = InMemoryClient.getByProcessWith({ cache })
@@ -255,7 +259,7 @@ export const createResultApis = async (ctx) => {
     buildAndSign: signerClient.buildAndSignWith({ MU_WALLET, logger: processMsgLogger }),
     fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: processMsgLogger }),
     logger,
-    isWallet: gatewayClient.isWalletWith({ fetch, histogram, GRAPHQL_URL: ctx.GRAPHQL_URL, logger: processMsgLogger, setById, getById }),
+    isWallet: gatewayClient.isWalletWith({ fetch, histogram, ARWEAVE_URL, logger: processMsgLogger, setById, getById }),
     writeDataItemArweave: uploaderClient.uploadDataItemWith({ UPLOADER_URL, logger: processMsgLogger, fetch, histogram })
   })
 


### PR DESCRIPTION
Closes #894 

This PR separates `GRAPHQL_URL` into two separate configurations:

- `ARWEAVE_URL`: the host of the Arweave http server to be used by the MU
- `GRAPHQL_URL`: the host of the Arweave GraphQL server to be used by the MU

Before these two services were conflated, when they are actually separate services.

This functionality matches the behavior of the CU, by allowing a default `GATEWAY_URL` as a default configuration fallback that is used to default both values, if not specified.

Finally, `isWallet` was refactored to use the separate `ARWEAVE_URL`, in lieu of parsing the structure of `GRAPHQL_URL`, which was not only an incorrect conflation (as described above), but brittle in the the sense that it assumed a specific structure of the string