### PR TITLE
Jeremiahstockdale/implement mu retries failures metric

### DIFF
--- a/servers/cu/src/domain/client/metrics.js
+++ b/servers/cu/src/domain/client/metrics.js
@@ -36,6 +36,18 @@ export const gaugeWith = ({ prefix = 'ao_cu' } = {}) => {
     const g = new PromClient.Gauge({
       name: `${prefix}_${name}`,
       help: description,
+      /**
+       * We abstract the use of 'this'
+       * to the collect function here.
+       *
+       * This way, the client may provide a function
+       * that simply returns the collected value to set,
+       * which will this call set here
+       */
+      ...(collect
+        ? { collect: async function () { this.set(await collect()) } }
+        : {}
+      ),
       enableExemplars: true
     })
 

--- a/servers/cu/src/domain/client/metrics.js
+++ b/servers/cu/src/domain/client/metrics.js
@@ -36,18 +36,6 @@ export const gaugeWith = ({ prefix = 'ao_cu' } = {}) => {
     const g = new PromClient.Gauge({
       name: `${prefix}_${name}`,
       help: description,
-      /**
-       * We abstract the use of 'this'
-       * to the collect function here.
-       *
-       * This way, the client may provide a function
-       * that simply returns the collected value to set,
-       * which will this call set here
-       */
-      ...(collect
-        ? { collect: async function () { this.set(await collect()) } }
-        : {}
-      ),
       enableExemplars: true
     })
 

--- a/servers/mu/src/domain/clients/metrics.js
+++ b/servers/mu/src/domain/clients/metrics.js
@@ -32,7 +32,7 @@ export const timer = (label, ctx) => {
 }
 
 export const counterWith = ({ prefix = 'ao_mu' } = {}) => {
-  return ({ name, description, collect, labelNames = [] }) => {
+  return ({ name, description, labelNames = [] }) => {
     const c = new PromClient.Counter({
       name: `${prefix}_${name}`,
       help: description,

--- a/servers/mu/src/domain/clients/metrics.js
+++ b/servers/mu/src/domain/clients/metrics.js
@@ -37,18 +37,6 @@ export const counterWith = ({ prefix = 'ao_mu' } = {}) => {
       name: `${prefix}_${name}`,
       help: description,
       labelNames,
-      /**
-       * We abstract the use of 'this'
-       * to the collect function here.
-       *
-       * This way, the client may provide a function
-       * that simply returns the collected value to set,
-       * which will this call set here
-       */
-      ...(collect
-        ? { collect: async function () { this.set(await collect()) } }
-        : {}
-      ),
       enableExemplars: true
     })
 

--- a/servers/mu/src/domain/clients/metrics.js
+++ b/servers/mu/src/domain/clients/metrics.js
@@ -31,6 +31,33 @@ export const timer = (label, ctx) => {
   }
 }
 
+export const counterWith = ({ prefix = 'ao_mu' } = {}) => {
+  return ({ name, description, collect, labelNames = [] }) => {
+    const c = new PromClient.Counter({
+      name: `${prefix}_${name}`,
+      help: description,
+      labelNames,
+      /**
+       * We abstract the use of 'this'
+       * to the collect function here.
+       *
+       * This way, the client may provide a function
+       * that simply returns the collected value to set,
+       * which will this call set here
+       */
+      ...(collect
+        ? { collect: async function () { this.set(await collect()) } }
+        : {}
+      ),
+      enableExemplars: true
+    })
+
+    return {
+      inc: (n) => c.inc(n)
+    }
+  }
+}
+
 export const gaugeWith = ({ prefix = 'ao_mu' } = {}) => {
   return ({ name, description, collect, labelNames = [] }) => {
     const g = new PromClient.Gauge({

--- a/servers/mu/src/domain/index.js
+++ b/servers/mu/src/domain/index.js
@@ -28,7 +28,8 @@ import { processAssignWith } from './api/processAssign.js'
 
 import { createLogger } from './logger.js'
 import { cuFetchWithCache } from './lib/cu-fetch-with-cache.js'
-import { handleWorkerQueueMessage } from './lib/handle-worker-queue-message.js'
+import { handleWorkerMetricsMessage } from './lib/handle-worker-metrics-message.js'
+
 export { errFrom } from './utils.js'
 
 const { DataItem } = warpArBundles
@@ -48,7 +49,7 @@ const histogram = MetricsClient.histogramWith()({
 const maximumQueueArray = new Array(60).fill(0)
 const maximumQueueTimeArray = new Array(60).fill(undefined)
 
-const workerQueueGauge = MetricsClient.gaugeWith({})({
+MetricsClient.gaugeWith({})({
   name: 'queue_size',
   description: 'The size of the queue',
   collect: () => apply(Math.max, maximumQueueArray)
@@ -56,6 +57,17 @@ const workerQueueGauge = MetricsClient.gaugeWith({})({
 const cronMonitorGauge = MetricsClient.gaugeWith({})({
   name: 'running_cron_monitor',
   description: 'The number of cron monitors running'
+})
+const taskRetriesGauge = MetricsClient.gaugeWith({})({
+  name: 'task_retries',
+  description: 'The number of retries a task requires',
+  labelNames: ['retries', 'status']
+})
+
+const errorStageGauge = MetricsClient.gaugeWith({})({
+  name: 'error_stage',
+  description: 'The number of errors at a given stage',
+  labelNames: ['stage', 'type']
 })
 
 /**
@@ -143,7 +155,7 @@ export const createApis = async (ctx) => {
   })
 
   const broadcastChannel = new BroadcastChannel('mu-worker')
-  broadcastChannel.onmessage = (event) => handleWorkerQueueMessage({ queueGauge: workerQueueGauge, maximumQueueArray, maximumQueueTimeArray })({ payload: event.data })
+  broadcastChannel.onmessage = (event) => handleWorkerMetricsMessage({ retriesGauge: taskRetriesGauge, stageGauge: errorStageGauge, maximumQueueArray, maximumQueueTimeArray })({ payload: event.data })
 
   const enqueueResults = async (...results) => {
     return workerPool.exec('enqueueResults', results)

--- a/servers/mu/src/domain/lib/handle-worker-metrics-message.test.js
+++ b/servers/mu/src/domain/lib/handle-worker-metrics-message.test.js
@@ -1,0 +1,108 @@
+import { describe, test } from 'node:test'
+
+import { handleWorkerMetricsMessage } from './handle-worker-metrics-message.js'
+import assert from 'node:assert'
+
+describe('handle-worker-metrics-message', () => {
+  describe('queue-size', () => {
+    test('arrays are updated if purpose is queue-size', () => {
+      const maximumQueueArray = new Array(60).fill(0)
+      const maximumQueueTimeArray = new Array(60).fill(undefined)
+      const handleMessage = handleWorkerMetricsMessage({
+        maximumQueueArray,
+        maximumQueueTimeArray
+      })
+
+      assert.equal(maximumQueueArray[1], 0)
+      assert.equal(maximumQueueTimeArray[1], undefined)
+      handleMessage({ payload: { purpose: 'queue-size', size: 123, time: 1000 } })
+      assert.equal(maximumQueueArray[1], 123)
+      assert.equal(maximumQueueTimeArray[1], 1000)
+    })
+
+    test('arrays are not updated if purpose is not queue-size', () => {
+      const maximumQueueArray = new Array(60).fill(0)
+      const maximumQueueTimeArray = new Array(60).fill(undefined)
+      const handleMessage = handleWorkerMetricsMessage({
+        maximumQueueArray,
+        maximumQueueTimeArray
+      })
+
+      handleMessage({ payload: { purpose: 'foo-bar', size: 123, time: 1000 } })
+      assert.equal(maximumQueueArray[1], 0)
+      assert.equal(maximumQueueTimeArray[1], undefined)
+    })
+  })
+
+  describe('task-retries', () => {
+    test('gauge incremented if purpose is task-retries', () => {
+      let gaugeIncremented = false
+      const handleMessage = handleWorkerMetricsMessage({
+        retriesGauge: {
+          inc: ({ retries, status }) => {
+            assert.equal(retries, 3)
+            assert.equal(status, 'success')
+            gaugeIncremented = true
+          }
+        }
+      })
+
+      handleMessage({ payload: { purpose: 'task-retries', retries: 3, status: 'success' } })
+      assert.ok(gaugeIncremented)
+    })
+
+    test('gauge incremented if purpose is task-retries, retry greater than 10', () => {
+      let gaugeIncremented = false
+      const handleMessage = handleWorkerMetricsMessage({
+        retriesGauge: {
+          inc: ({ retries, status }) => {
+            assert.equal(retries, '10+')
+            assert.equal(status, 'failure')
+            gaugeIncremented = true
+          }
+        }
+      })
+
+      handleMessage({ payload: { purpose: 'task-retries', retries: 15, status: 'failure' } })
+      assert.ok(gaugeIncremented)
+    })
+
+    test('gauge not incremented if purpose is not task-retries', () => {
+      let gaugeIncremented = false
+      const handleMessage = handleWorkerMetricsMessage({
+        retriesGauge: { inc: () => { gaugeIncremented = true } }
+      })
+
+      handleMessage({ payload: { purpose: 'task-retries-foo' } })
+      assert.ok(!gaugeIncremented)
+    })
+  })
+
+  describe('error-stage', () => {
+    test('gauge incremented if purpose is error-stage', () => {
+      let gaugeIncremented = false
+      const handleMessage = handleWorkerMetricsMessage({
+        stageGauge: {
+          inc: ({ stage, type }) => {
+            assert.equal(stage, 'foo-stage')
+            assert.equal(type, 'assign')
+            gaugeIncremented = true
+          }
+        }
+      })
+
+      handleMessage({ payload: { purpose: 'error-stage', stage: 'foo-stage', type: 'assign' } })
+      assert.ok(gaugeIncremented)
+    })
+
+    test('gauge not incremented if purpose is not error-stage', () => {
+      let gaugeIncremented = false
+      const handleMessage = handleWorkerMetricsMessage({
+        retriesGauge: { inc: () => { gaugeIncremented = true } }
+      })
+
+      handleMessage({ payload: { purpose: 'error-stage-foo', type: 'message' } })
+      assert.ok(!gaugeIncremented)
+    })
+  })
+})


### PR DESCRIPTION
closes #914 

This PR sends the retry data from tasks within the MU to grafana. 
the `task-retries` is sent with `status` of `failure` or `success`  to differentiate between a task that retried 5 times and succeeded on the fifth, versus a task that errored on every retry.

the other metric created is `error-stage` which tracks the gauge of what `stage` caused the task to fail.

Note that `task-retries` will be sent after either all retries have been used, or the task ran successfully. But the `error-stage` will run on every retry