### PR TITLE
perf(cu): add total evals, gas used metrics to cu #917

### DIFF
--- a/servers/cu/src/domain/api/dryRun.js
+++ b/servers/cu/src/domain/api/dryRun.js
@@ -81,7 +81,12 @@ export function dryRunWith (env) {
            * Otherwise, we are evaluating up to the latest
            */
           exact: !!messageTxId,
-          needsMemory: true
+          needsMemory: true,
+          /**
+           * Add an indicator that this eval stream is part of a dry run.
+           * This is used for metric purposes.
+           */
+          dryRun: true
         })
       )
       /**
@@ -161,7 +166,7 @@ export function dryRunWith (env) {
              * Pass a messages stream to evaluate that only emits the single dry-run
              * message and then completes
              */
-            return evaluate({ ...ctx, messages: Readable.from(dryRunMessage()) })
+            return evaluate({ ...ctx, dryRun: true, messages: Readable.from(dryRunMessage()) })
           })
       })
       .map((res) => res.output)

--- a/servers/cu/src/domain/api/readState.js
+++ b/servers/cu/src/domain/api/readState.js
@@ -35,7 +35,7 @@ export function readStateWith (env) {
   const loadModule = loadModuleWith(env)
   const evaluate = evaluateWith(env)
 
-  return ({ processId, messageId, to, ordinate, cron, exact, needsMemory }) => {
+  return ({ processId, messageId, to, ordinate, cron, exact, needsMemory, dryRun = false }) => {
     messageId = messageId || [to, ordinate, cron].filter(isNotNil).join(':') || 'latest'
 
     const stats = {
@@ -79,7 +79,7 @@ export function readStateWith (env) {
          * there is only one instance of the work used to resolve each Async,
          * every time, thus preventing duplication of work
          */
-        pending = of({ id: processId, messageId, to, ordinate, cron, stats, needsMemory })
+        pending = of({ id: processId, messageId, to, ordinate, cron, stats, needsMemory, dryRun })
           .chain(loadProcessMeta)
           .chain(loadProcess)
           .chain(loadModule)

--- a/servers/cu/src/domain/index.js
+++ b/servers/cu/src/domain/index.js
@@ -195,6 +195,21 @@ export const createApis = async (ctx) => {
     compute: fromPromise(() => _metrics.metrics())
   }
 
+  const evaluationCounter = MetricsClient.counterWith({})({
+    name: 'total_evaluations',
+    description: 'The total number of evaluations on a CU',
+    labelNames: ['processId', 'cron', 'dryRun', 'error']
+  })
+
+  /**
+   * TODO: Gas can grow to a huge number. We need to make sure this doesn't crash when that happens
+   */
+  // const gasCounter = MetricsClient.counterWith({})({
+  //   name: 'total_gas_used',
+  //   description: 'The total number of gas used on a CU',
+  //   labelNames: ['processId', 'cron', 'dryRun', 'error']
+  // })
+
   const sharedDeps = (logger) => ({
     loadTransactionMeta: ArweaveClient.loadTransactionMetaWith({ fetch: ctx.fetch, GRAPHQL_URL: ctx.GRAPHQL_URL, logger }),
     loadTransactionData: ArweaveClient.loadTransactionDataWith({ fetch: ctx.fetch, ARWEAVE_URL: ctx.ARWEAVE_URL, logger }),
@@ -229,6 +244,8 @@ export const createApis = async (ctx) => {
       saveCheckpoint,
       logger
     }),
+    evaluationCounter,
+    // gasCounter,
     saveProcess: AoProcessClient.saveProcessWith({ db: sqlite, logger }),
     findEvaluation: AoEvaluationClient.findEvaluationWith({ db: sqlite, logger }),
     saveEvaluation: AoEvaluationClient.saveEvaluationWith({ db: sqlite, logger }),

--- a/servers/cu/src/domain/lib/evaluate.js
+++ b/servers/cu/src/domain/lib/evaluate.js
@@ -75,6 +75,8 @@ function doesMessageExistWith ({ findMessageBefore }) {
  * @returns {Evaluate}
  */
 export function evaluateWith (env) {
+  const evaluationCounter = env.evaluationCounter
+  // const gasCounter = env.gasCounter
   const logger = env.logger.child('evaluate')
   env = { ...env, logger }
 
@@ -237,6 +239,15 @@ export function evaluateWith (env) {
                             ctx.stats.messages.error = ctx.stats.messages.error || 0
                             ctx.stats.messages.error++
                           }
+
+                          /**
+                           * Increments gauges for total evaluations
+                           */
+                          evaluationCounter.inc(1, { cron: Boolean(cron), dryRun: Boolean(ctx.dryRun) }, { processId: ctx.id, error: Boolean(output.Error) })
+                          /**
+                           * TODO: Gas can grow to a huge number. We need to make sure this doesn't crash when that happens
+                           */
+                          // gasCounter.inc(output.GasUsed ?? 0, { cron: Boolean(cron), dryRun: Boolean(ctx.dryRun) }, { processId: ctx.id, error: Boolean(output.Error) })
 
                           return output
                         })

--- a/servers/cu/src/domain/lib/evaluate.test.js
+++ b/servers/cu/src/domain/lib/evaluate.test.js
@@ -45,6 +45,12 @@ describe('evaluate', () => {
       findMessageBefore: async () => { throw { status: 404 } },
       loadEvaluator: evaluateHappyMessage,
       saveLatestProcessMemory: async () => {},
+      evaluationCounter: {
+        inc: () => undefined
+      },
+      gasCounter: {
+        inc: () => undefined
+      },
       logger
     })
 
@@ -172,6 +178,12 @@ describe('evaluate', () => {
         }
       },
       saveLatestProcessMemory: async () => {},
+      evaluationCounter: {
+        inc: () => undefined
+      },
+      gasCounter: {
+        inc: () => undefined
+      },
       logger
     }
 
@@ -280,6 +292,12 @@ describe('evaluate', () => {
         }
       },
       saveLatestProcessMemory: async () => {},
+      evaluationCounter: {
+        inc: () => undefined
+      },
+      gasCounter: {
+        inc: () => undefined
+      },
       logger
     }
 
@@ -422,6 +440,12 @@ describe('evaluate', () => {
         }
       },
       saveLatestProcessMemory: async () => {},
+      evaluationCounter: {
+        inc: () => undefined
+      },
+      gasCounter: {
+        inc: () => undefined
+      },
       logger
     }
 
@@ -528,6 +552,12 @@ describe('evaluate', () => {
         return { Memory: Buffer.from('Hello world') }
       },
       saveLatestProcessMemory: async () => {},
+      evaluationCounter: {
+        inc: () => undefined
+      },
+      gasCounter: {
+        inc: () => undefined
+      },
       logger
     })
 


### PR DESCRIPTION
Closes #917 

This PR adds two separate but related metrics to the CU: total message evaluations and total gas used. They have added labels: processId, cron, dryRun, and error. Their are two views per metric worth visualizing: All the CUs over time, so we can see which units are doing the most evals/using the most gas; and on a per-unit (and per-process) basis, we can see what % of evals/gas are cron, dryrun, error.