### PR TITLE
perf(scheduler-utils): add exponential backoff to gateway requests

### DIFF
--- a/scheduler-utils/README.md
+++ b/scheduler-utils/README.md
@@ -99,6 +99,8 @@ specify those coonfigurations by providing their values `connect`. You can curre
 - The `GRAPHQL_URL`
 - The In-Memory `cacheSize`
 - Following Redirects `followRedirects`, a boolean that optimizes scheduler routing if `true`
+- `GRAPHQL_MAX_RETRIES`, the maximum amount of retries for failed gateway queries
+- `GRAPHQL_RETRY_BACKOFF`, the initial delay for a gateway query retry. Doubled for each successive retry
 
 > If you'd like to use no In-Memory Cache, and load the record from chain every time, then set the `cacheSize` to `0`
 
@@ -108,7 +110,9 @@ import { connect } from "@permaweb/ao-scheduler-utils";
 const { validate, locate, raw } = connect({
   GRAPHQL_URL: "...",
   cacheSize: 1000,
-  followRedirects: true
+  followRedirects: true,
+  GRAPHQL_MAX_RETRIES: 0,
+  GRAPHQL_RETRY_BACKOFF: 300
 });
 ```
 

--- a/scheduler-utils/src/index.browser.js
+++ b/scheduler-utils/src/index.browser.js
@@ -5,7 +5,9 @@ export * from './index.common.js'
 const GRAPHQL_URL = globalThis.GRAPHQL_URL || undefined
 const CACHE_SIZE = globalThis.SCHEDULER_UTILS_CACHE_SIZE || undefined
 const FOLLOW_REDIRECTS = globalThis.SCHEDULER_UTILS_FOLLOW_REDIRECTS === 'true' || undefined
+const GRAPHQL_MAX_RETRIES = globalThis.GRAPHQL_MAX_RETRIES || 0
+const GRAPHQL_RETRY_BACKOFF = globalThis.GRAPHQL_RETRY_BACKOFF || 300
 
-const { locate, validate, raw } = connect({ GRAPHQL_URL, cacheSize: CACHE_SIZE, followRedirects: FOLLOW_REDIRECTS })
+const { locate, validate, raw } = connect({ GRAPHQL_URL, cacheSize: CACHE_SIZE, followRedirects: FOLLOW_REDIRECTS, GRAPHQL_MAX_RETRIES, GRAPHQL_RETRY_BACKOFF })
 
 export { locate, validate, raw }

--- a/scheduler-utils/src/index.js
+++ b/scheduler-utils/src/index.js
@@ -5,7 +5,9 @@ export * from './index.common.js'
 const GRAPHQL_URL = process.env.GRAPHQL_URL || undefined
 const CACHE_SIZE = process.env.SCHEDULER_UTILS_CACHE_SIZE || undefined
 const FOLLOW_REDIRECTS = process.env.SCHEDULER_UTILS_FOLLOW_REDIRECTS === 'true' || undefined
+const GRAPHQL_MAX_RETRIES = process.env.GRAPHQL_MAX_RETRIES || 0
+const GRAPHQL_RETRY_BACKOFF = process.env.GRAPHQL_RETRY_BACKOFF || 300
 
-const { locate, validate, raw } = connect({ GRAPHQL_URL, cacheSize: CACHE_SIZE, followRedirects: FOLLOW_REDIRECTS })
+const { locate, validate, raw } = connect({ GRAPHQL_URL, cacheSize: CACHE_SIZE, followRedirects: FOLLOW_REDIRECTS, GRAPHQL_MAX_RETRIES, GRAPHQL_RETRY_BACKOFF })
 
 export { locate, validate, raw }

--- a/scheduler-utils/src/utils.js
+++ b/scheduler-utils/src/utils.js
@@ -2,3 +2,56 @@ export function trimSlash (str = '') {
   str = str.trim()
   return str.endsWith('/') ? trimSlash(str.slice(0, -1)) : str
 }
+
+/**
+ * A function that, given a function, will immediately invoke it,
+ * then retry it on errors, using an exponential backoff.
+ *
+ * If the final retry fails, then the overall Promise is rejected
+ * with that error
+ *
+ * @param {function} fn - the function to be called
+ * @param {{ maxRetries: number, delay: number }} param1 - the number of total retries and increased delay for each try
+ */
+export const backoff = (
+  fn,
+  { maxRetries = 0, delay = 300 }
+) => {
+  /**
+   * Recursive function that recurses with exponential backoff
+   */
+  const action = (retry, delay) => {
+    return Promise.resolve()
+      .then(fn)
+      .catch((err) => {
+        // Reached max number of retries
+        if (retry >= maxRetries) {
+          return Promise.reject(err)
+        }
+
+        /**
+         * increment the retry count Retry with an exponential backoff
+         */
+        const newRetry = retry + 1
+        const newDelay = delay + delay
+        /**
+         * Retry in {delay} milliseconds
+         */
+        return new Promise((resolve) => setTimeout(resolve, delay))
+          .then(() => action(newRetry, newDelay))
+      })
+  }
+
+  return action(0, delay)
+}
+
+/**
+ * Checks if a response is OK. Otherwise, throw response.
+ *
+ * @param {Response} res - The response to check
+ * @returns
+ */
+export const okRes = (res) => {
+  if (res.ok) return res
+  throw res
+}

--- a/scheduler-utils/src/utils.test.js
+++ b/scheduler-utils/src/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test'
 import * as assert from 'node:assert'
-import { trimSlash } from './utils.js'
+import { backoff, trimSlash } from './utils.js'
 
 describe('trimSlash', () => {
   test('should remove trailing slash from url', () => {
@@ -8,5 +8,77 @@ describe('trimSlash', () => {
     assert.equal(resultWithTrailingSlash, 'https://foo.bar')
     const resultWithoutTrailingSlash = trimSlash('https://foo.bar')
     assert.equal(resultWithoutTrailingSlash, 'https://foo.bar')
+  })
+})
+
+describe('backoff', () => {
+  function isPromise (obj) {
+    return (
+      !!obj &&
+      (typeof obj === 'object' || typeof obj === 'function') &&
+      typeof obj.then === 'function'
+    )
+  }
+
+  test('should return a promise', () => {
+    assert.ok(isPromise(
+      backoff(() => Promise.resolve(''), {
+        maxRetries: 0,
+        delay: 0
+      })
+    ))
+
+    assert.ok(isPromise(
+      backoff(() => '', {
+        maxRetries: 0,
+        delay: 0
+      })
+    ))
+  })
+
+  test('should not retry calling the function', async () => {
+    let count = 0
+    const fn = () => count++
+    await backoff(fn, {
+      maxRetries: 0,
+      delay: 0
+    })
+
+    assert.equal(count, 1)
+  })
+
+  test('should retry calling the function', async () => {
+    let count = 0
+    const fn = () => {
+      count++
+      return count
+        ? Promise.resolve('foo')
+        // eslint-disable-next-line
+        : Promise.reject('bar')
+    }
+
+    const res = await backoff(fn, {
+      maxRetries: 1,
+      delay: 0
+    })
+
+    assert.equal(res, 'foo')
+  })
+
+  test('should bubble the error if all retries are unsuccessful', async () => {
+    let count = 0
+    const fn = () => {
+      count++
+      // eslint-disable-next-line
+      return Promise.reject('bar')
+    }
+
+    await backoff(fn, {
+      maxRetries: 2,
+      delay: 0
+    }).catch(err => {
+      assert.equal(err, 'bar')
+      assert.equal(count, 3)
+    })
   })
 })


### PR DESCRIPTION
Sometimes, when their is no cache value, scheduler utils needs to query the gateway for a scheduler location. If this fails, add exponential backoff.