### PR TITLE
feat(connect): bump scheduler-utils and expose GRAPHQL_MAX_RETRIES and GRAPHQL_RETRY_BACKOFF

### DIFF
--- a/connect/package-lock.json
+++ b/connect/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@permaweb/aoconnect",
       "version": "0.0.57",
       "dependencies": {
-        "@permaweb/ao-scheduler-utils": "~0.0.20",
+        "@permaweb/ao-scheduler-utils": "~0.0.23",
         "buffer": "^6.0.3",
-        "debug": "^4.3.5",
+        "debug": "^4.3.6",
         "hyper-async": "^1.1.2",
         "mnemonist": "^0.39.8",
         "ramda": "^0.30.1",
@@ -443,17 +443,16 @@
       }
     },
     "node_modules/@permaweb/ao-scheduler-utils": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@permaweb/ao-scheduler-utils/-/ao-scheduler-utils-0.0.20.tgz",
-      "integrity": "sha512-bJkcmnQm/rCGqklJt46q5TnHfWkFzSBcSf9Z3uy8ylHRAheS9NyR1BJMAj3EXDjHCpg7JfnLRo6Uc3Xdw1lmOA==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@permaweb/ao-scheduler-utils/-/ao-scheduler-utils-0.0.23.tgz",
+      "integrity": "sha512-RtcWdHnrmvHbDVtqDX41P7ccCPA8IfYTXml4U/IgoaXIU/iUY0BfcMPwLSu2VxQCEfgLCfVASZxG0kZnh3xs3g==",
       "dependencies": {
         "lru-cache": "^10.2.2",
         "ramda": "^0.30.0",
         "zod": "^3.23.5"
       },
       "engines": {
-        "node": ">=18",
-        "yarn": "please-use-npm"
+        "node": ">=18"
       }
     },
     "node_modules/arconnect": {
@@ -554,9 +553,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -916,9 +915,9 @@
       "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
     },
     "@permaweb/ao-scheduler-utils": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@permaweb/ao-scheduler-utils/-/ao-scheduler-utils-0.0.20.tgz",
-      "integrity": "sha512-bJkcmnQm/rCGqklJt46q5TnHfWkFzSBcSf9Z3uy8ylHRAheS9NyR1BJMAj3EXDjHCpg7JfnLRo6Uc3Xdw1lmOA==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@permaweb/ao-scheduler-utils/-/ao-scheduler-utils-0.0.23.tgz",
+      "integrity": "sha512-RtcWdHnrmvHbDVtqDX41P7ccCPA8IfYTXml4U/IgoaXIU/iUY0BfcMPwLSu2VxQCEfgLCfVASZxG0kZnh3xs3g==",
       "requires": {
         "lru-cache": "^10.2.2",
         "ramda": "^0.30.0",
@@ -985,9 +984,9 @@
       }
     },
     "debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "requires": {
         "ms": "2.1.2"
       }

--- a/connect/package.json
+++ b/connect/package.json
@@ -45,9 +45,9 @@
     "test:integration": "cd ./test/e2e && npm test"
   },
   "dependencies": {
-    "@permaweb/ao-scheduler-utils": "~0.0.20",
+    "@permaweb/ao-scheduler-utils": "~0.0.23",
     "buffer": "^6.0.3",
-    "debug": "^4.3.5",
+    "debug": "^4.3.6",
     "hyper-async": "^1.1.2",
     "mnemonist": "^0.39.8",
     "ramda": "^0.30.1",

--- a/connect/src/index.browser.js
+++ b/connect/src/index.browser.js
@@ -6,8 +6,10 @@ const GATEWAY_URL = globalThis.GATEWAY_URL || undefined
 const MU_URL = globalThis.MU_URL || undefined
 const CU_URL = globalThis.CU_URL || undefined
 const GRAPHQL_URL = globalThis.GRAPHQL_URL || undefined
+const GRAPHQL_MAX_RETRIES = globalThis.GRAPHQL_MAX_RETRIES || undefined
+const GRAPHQL_RETRY_BACKOFF = globalThis.GRAPHQL_RETRY_BACKOFF || undefined
 
-const { result, results, message, spawn, monitor, unmonitor, dryrun, assign } = connect({ GATEWAY_URL, MU_URL, CU_URL, GRAPHQL_URL })
+const { result, results, message, spawn, monitor, unmonitor, dryrun, assign } = connect({ GATEWAY_URL, MU_URL, CU_URL, GRAPHQL_URL, GRAPHQL_MAX_RETRIES, GRAPHQL_RETRY_BACKOFF })
 
 export { result, results, message, spawn, monitor, unmonitor, dryrun, assign }
 export { connect }

--- a/connect/src/index.common.js
+++ b/connect/src/index.common.js
@@ -27,10 +27,12 @@ export { serializeCron } from './lib/serializeCron/index.js'
  *
  * - a GATEWAY_URL
  * - a GRAPHQL_URL (defaults to GATEWAY_URL/graphql)
+ * - a GRAPHQL_MAX_RETRIES. Defaults to 0
+ * - a GRAPHQL_RETRY_BACKOFF. Defaults to 300 (moot if GRAPHQL_MAX_RETRIES is set to 0)
  * - a Messenger Unit URL
  * - a Compute Unit URL
  *
- * If any url is not provided, an SDK default will be used.
+ * If any value is not provided, an SDK default will be used.
  * Invoking connect() with no parameters or an empty object is functionally equivalent
  * to using the top-lvl exports of the SDK ie.
  *
@@ -45,11 +47,13 @@ export { serializeCron } from './lib/serializeCron/index.js'
  * } from '@permaweb/ao-sdk';
  *
  * // These are functionally equivalent
- * connect() == { spawn, message, result, monitor }
+ * connect() == { spawn, message, result, results, monitor }
  *
  * @typedef Services
  * @property {string} [GATEWAY_URL] - the url of the desried Gateway.
  * @property {string} [GRAPHQL_URL] - the url of the desired Arweave Gateway GraphQL Server
+ * @property {number} [GRAPHQL_MAX_RETRIES] - the number of times to retry querying the gateway, utilizing an exponential backoff
+ * @property {number} [GRAPHQL_RETRY_BACKOFF] - the initial backoff, in milliseconds (moot if GRAPHQL_MAX_RETRIES is set to 0)
  * @property {string} [MU_URL] - the url of the desried ao Messenger Unit.
  * @property {string} [CU_URL] - the url of the desried ao Compute Unit.
  *
@@ -57,6 +61,8 @@ export { serializeCron } from './lib/serializeCron/index.js'
  */
 export function connect ({
   GRAPHQL_URL,
+  GRAPHQL_MAX_RETRIES,
+  GRAPHQL_RETRY_BACKOFF,
   GATEWAY_URL = DEFAULT_GATEWAY_URL,
   MU_URL = DEFAULT_MU_URL,
   CU_URL = DEFAULT_CU_URL
@@ -65,7 +71,7 @@ export function connect ({
 
   if (!GRAPHQL_URL) GRAPHQL_URL = joinUrl({ url: GATEWAY_URL, path: '/graphql' })
 
-  const { validate } = schedulerUtilsConnect({ cacheSize: 100, GRAPHQL_URL })
+  const { validate } = schedulerUtilsConnect({ cacheSize: 100, GRAPHQL_URL, GRAPHQL_MAX_RETRIES, GRAPHQL_RETRY_BACKOFF })
 
   const processMetaCache = SuClient.createProcessMetaCache({ MAX_SIZE: 25 })
 

--- a/connect/src/index.js
+++ b/connect/src/index.js
@@ -5,8 +5,10 @@ const GATEWAY_URL = process.env.GATEWAY_URL || undefined
 const MU_URL = process.env.MU_URL || undefined
 const CU_URL = process.env.CU_URL || undefined
 const GRAPHQL_URL = process.env.GRAPHQL_URL || undefined
+const GRAPHQL_MAX_RETRIES = process.env.GRAPHQL_MAX_RETRIES || undefined
+const GRAPHQL_RETRY_BACKOFF = process.env.GRAPHQL_RETRY_BACKOFF || undefined
 
-const { result, results, message, spawn, monitor, unmonitor, dryrun, assign } = connect({ GATEWAY_URL, MU_URL, CU_URL, GRAPHQL_URL })
+const { result, results, message, spawn, monitor, unmonitor, dryrun, assign } = connect({ GATEWAY_URL, MU_URL, CU_URL, GRAPHQL_URL, GRAPHQL_MAX_RETRIES, GRAPHQL_RETRY_BACKOFF })
 
 export { result, results, message, spawn, monitor, unmonitor, dryrun, assign }
 export { connect }


### PR DESCRIPTION
Title says it all. Just exposing some functionality on `connect` that was recently added to `scheduler-utils`