### PR TITLE
refactor(dev-cli): rename build function to exec for clarity and added correct description

### DIFF
--- a/dev-cli/src/commands/exec.js
+++ b/dev-cli/src/commands/exec.js
@@ -3,7 +3,7 @@
 import { Command } from '../deps.js'
 import { VERSION } from '../versions.js'
 
-export async function build (_, command) {
+export async function exec (_, command) {
   const pwd = Deno.cwd()
   const p = Deno.run({
     cmd: [
@@ -21,6 +21,6 @@ export async function build (_, command) {
 }
 
 export const command = new Command()
-  .description('Build the Lua Project into WASM')
+  .description('Exec command in the container ( ie: exec emcmake cmake . )')
   .arguments('<command:string>')
-  .action(build)
+  .action(exec)


### PR DESCRIPTION
Just updated the exec.js to add correct description and rename the function to exec