### PR TITLE
fix(mu): throw error when procs.json is corrupted

### DIFF
--- a/servers/mu/src/domain/index.js
+++ b/servers/mu/src/domain/index.js
@@ -257,18 +257,12 @@ export const createApis = async (ctx) => {
         if (!fs.existsSync(PROC_FILE_PATH)) return
         const data = fs.readFileSync(PROC_FILE_PATH, 'utf8')
 
-        let obj
-        try {
-          /**
-           * This .replace is used to fix corrupted json files
-           * it should be removed later now that the corruption
-           * issue is solved
-           */
-          obj = JSON.parse(data.replace(/}\s*"/g, ',"'))
-        } catch (_e) {
-          obj = {}
-        }
-        return obj
+        /**
+         * This .replace is used to fix corrupted json files
+         * it should be removed later now that the corruption
+         * issue is solved
+         */
+        return JSON.parse(data.replace(/}\s*"/g, ',"'))
       },
       saveProcs
     })


### PR DESCRIPTION
Closes #934.

Instead of swallowing the error when JSON.parse fails, we now allow it to bubble