### PR TITLE
fix(loader): update types & point to the correct declaration file

### DIFF
--- a/loader/package.json
+++ b/loader/package.json
@@ -9,7 +9,7 @@
   "sideEffects": false,
   "type": "module",
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.cts",
   "files": [
     "./dist"
   ],

--- a/loader/src/index.cjs
+++ b/loader/src/index.cjs
@@ -49,7 +49,7 @@ const Wasm64 = require('./formats/wasm64-emscripten.cjs')
 
 /**
  * @typedef Environment
- * @property {{id: string, owner: string, tags: Tag[]}} process
+ * @property {{Id: string, Owner: string, Tags: Tag[]}} Process
  */
 
 /**

--- a/loader/src/index.cjs
+++ b/loader/src/index.cjs
@@ -63,10 +63,10 @@ const Wasm64 = require('./formats/wasm64-emscripten.cjs')
 
 /**
  * @callback handleFunction
- * @param {ArrayBuffer | NULL} buffer
+ * @param {ArrayBuffer | null} buffer
  * @param {Message} msg
  * @param {Environment} env
- * @returns {HandleResponse}
+ * @returns {Promise<HandleResponse>}
  */
 
 /**

--- a/loader/src/index.cjs
+++ b/loader/src/index.cjs
@@ -70,18 +70,23 @@ const Wasm64 = require('./formats/wasm64-emscripten.cjs')
  */
 
 /**
+ * @typedef {'wasm32-unknown-emscripten'|
+ * 'wasm32-unknown-emscripten2'|
+ * 'wasm32-unknown-emscripten3'|
+ * 'wasm64-unknown-emscripten-draft_2024_02_15'} BinaryFormat
+ */
+
+/**
  * @typedef Options
- * @property {string} format
- * @property {string} input
- * @property {string} output
- * @property {string} memory
- * @property {string} compute
- * @property {String[]} extensions
+ * @property {BinaryFormat} [format]
+ * @property {number} [computeLimit]
+ * @property {string} [memoryLimit]
+ * @property {string[]} [extensions]
  */
 
 /**
  * @param {ArrayBuffer} binary
- * @param {Options} options
+ * @param {Options} [options]
  * @returns {Promise<handleFunction>}
  */
 module.exports = async function (binary, options) {


### PR DESCRIPTION
This PR aims to fix the out of date typings in `@permaweb/ao-loader` and updates the `package.json` file to refer to the correct declaration file.

Fixes: #873 #593