### PR TITLE
chore(cu): map signature, data, anchor fields in loadprocess #971

### DIFF
--- a/servers/cu/src/domain/client/ao-su.js
+++ b/servers/cu/src/domain/client/ao-su.js
@@ -302,7 +302,10 @@ export const loadProcessWith = ({ fetch, logger }) => {
          */
         processId: always(processId),
         timestamp: path(['timestamp']),
-        nonce: always(0)
+        nonce: always(0),
+        signature: path(['signature']),
+        data: path(['data']),
+        anchor: path(['anchor'])
       }))
   }
 }

--- a/servers/cu/src/domain/client/ao-su.test.js
+++ b/servers/cu/src/domain/client/ao-su.test.js
@@ -2,8 +2,8 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 
-import { loadMessageMetaSchema } from '../dal.js'
-import { loadMessageMetaWith, mapNode } from './ao-su.js'
+import { loadMessageMetaSchema, loadProcessSchema, loadTimestampSchema } from '../dal.js'
+import { loadMessageMetaWith, loadProcessWith, loadTimestampWith, mapNode } from './ao-su.js'
 import { messageSchema } from '../model.js'
 import { createLogger } from '../logger.js'
 
@@ -248,6 +248,88 @@ describe('ao-su', () => {
         processId: 'process-123',
         timestamp: 12345,
         nonce: 3
+      })
+    })
+  })
+
+  describe('loadProcessesWith', () => {
+    test('load the process metadata', async () => {
+      const loadProcess = loadProcessSchema.implement(loadProcessWith({
+        fetch: async () => {
+          return {
+            ok: true,
+            json: () => {
+              return {
+                process_id: 'pid-2',
+                block: '000000001',
+                owner: {
+                  address: 'owner-address-1',
+                  key: 'owner-key-1'
+                },
+                tags: [
+                  { name: 'Foo', value: 'Bar' }
+                ],
+                timestamp: 123456,
+                data: '1984',
+                anchor: null,
+                signature: 'signature-1'
+              }
+            }
+          }
+        },
+        logger
+      }))
+      const result = await loadProcess({
+        suUrl: 'https://foo.bar',
+        processId: 'pid-1'
+      })
+      assert.deepStrictEqual(result, {
+        owner: {
+          address: 'owner-address-1',
+          key: 'owner-key-1'
+        },
+        tags: [
+          { name: 'Foo', value: 'Bar' }
+        ],
+        block: {
+          height: 1,
+          timestamp: 123456
+        },
+        processId: 'pid-1',
+        timestamp: 123456,
+        signature: 'signature-1',
+        data: '1984',
+        nonce: 0,
+        anchor: null
+      })
+    })
+  })
+
+  describe('loadTimestampWith', () => {
+    test('load process timestamp and block height', async () => {
+      const loadTimestamp = loadTimestampSchema.implement(loadTimestampWith({
+        fetch: async () => {
+          return {
+            ok: true,
+            json: () => {
+              return {
+                block_height: '0000001',
+                timestamp: '123456'
+              }
+            }
+          }
+        },
+        logger
+      }))
+
+      const result = await loadTimestamp({
+        suUrl: 'https://foo.bar',
+        processId: 'pid-1'
+      })
+
+      assert.deepStrictEqual(result, {
+        timestamp: 123456,
+        height: 1
       })
     })
   })


### PR DESCRIPTION
Closes #971.

Maps signature, data, and anchor fields to return from SU loadProcess.