### PR TITLE
chore(mu): remove ao-spawn-sucess from mu #926

### DIFF
--- a/servers/mu/src/domain/lib/build-success-tx.js
+++ b/servers/mu/src/domain/lib/build-success-tx.js
@@ -39,13 +39,7 @@ export function buildSuccessTxWith ({ buildAndSign, logger }) {
          * by an aos Handler
          */
         { name: 'Process', value: ctx.processTx },
-        { name: 'Action', value: 'Spawned' },
-        /**
-         * The id of the newly spawned Process
-         *
-         * TODO: Maybe be able to remove later, kept for backwards compat.
-         */
-        { name: 'AO-Spawn-Success', value: ctx.processTx }
+        { name: 'Action', value: 'Spawned' }
       ]))
       .chain(fromPromise((tags) => buildAndSign({
         processId: ctx.cachedSpawn.processId,

--- a/servers/mu/src/domain/lib/build-success-tx.test.js
+++ b/servers/mu/src/domain/lib/build-success-tx.test.js
@@ -31,8 +31,7 @@ describe('buildSuccessTx', () => {
             { name: 'Variant', value: 'ao.TN.1' },
             { name: 'Type', value: 'Message' },
             { name: 'Process', value: 'pid-2' },
-            { name: 'Action', value: 'Spawned' },
-            { name: 'AO-Spawn-Success', value: 'pid-2' }
+            { name: 'Action', value: 'Spawned' }
           ]
         )
         return {


### PR DESCRIPTION
Closes #926 

Removes 'Ao-Spawn-Success' tag being built on the MU spawn success tx.