### PR TITLE
fix: c build script

### DIFF
--- a/dev-cli/container/src/ao_module_lib/languages/c.py
+++ b/dev-cli/container/src/ao_module_lib/languages/c.py
@@ -2,7 +2,7 @@ import glob
 from ao_module_lib.definition import Definition
 from ao_module_lib.file import BundleFile
 
-def inject_c_files(definition: Definition, c_program: str, c_source_files: list, link_libraries: list):
+def inject_c_files(definition: Definition, c_program: str, c_source_files: list):
 
     c_header_files = []
     

--- a/dev-cli/src/commands/build.js
+++ b/dev-cli/src/commands/build.js
@@ -13,7 +13,7 @@ export async function build () {
       'linux/amd64',
       '-v',
       `${pwd}:/src`,
-      `p3rmaw3b/ao:${VERSION.IMAGE}`,
+      `p3rmaw3b/ao`,
       'ao-build-module'
     ]
   })


### PR DESCRIPTION
```
$ ao build

Traceback (most recent call last):
  File "/usr/local/bin/ao-build-module", line 159, in <module>
    main()
  File "/usr/local/bin/ao-build-module", line 73, in main
    c_program = inject_c_files(definition, c_program, c_source_files)
TypeError: inject_c_files() missing 1 required positional argument: 'link_libraries'

```

Fixed the error by removing it as an argument

had to edit the build.js file so that it routed to same image, will need attention too because the container build script builds it to p3rmaw3b/ao but the updates didnt reflect in p3rmaw3b/ao:1.2.0  (  ${VERSION.IMAGE}  ) which is used by the build command

fixed output 

```
emcc: warning: -sMEMORY64 is still experimental. Many features may not work. [-Wexperimental]
cache:INFO: generating system asset: symbol_lists/7722a3472580a3a3ad7076282253431c6535d1a0.json... (this will be cached in "/emsdk/upstream/emscripten/cache/symbol_lists/7722a3472580a3a3ad7076282253431c6535d1a0.json" for subsequent builds)
cache:INFO:  - ok
```