### PR TITLE
perf(cu): use cached readState on dryRun if within allowed max age #984

### DIFF
--- a/servers/cu/src/bootstrap.js
+++ b/servers/cu/src/bootstrap.js
@@ -53,6 +53,9 @@ async function readFile (file) {
 export const createApis = async (ctx) => {
   ctx.logger('Creating business logic apis')
 
+  const setTimeout = (...args) => lt.setTimeout(...args)
+  const clearTimeout = (...args) => lt.clearTimeout(...args)
+
   const { locate } = schedulerUtilsConnect({
     cacheSize: 100,
     GRAPHQL_URL: ctx.GRAPHQL_URL,
@@ -230,8 +233,8 @@ export const createApis = async (ctx) => {
     TTL: ctx.PROCESS_MEMORY_CACHE_TTL,
     writeProcessMemoryFile,
     logger: ctx.logger,
-    setTimeout: (...args) => lt.setTimeout(...args),
-    clearTimeout: (...args) => lt.clearTimeout(...args)
+    setTimeout,
+    clearTimeout
   })
 
   const loadWasmModule = WasmClient.loadWasmModuleWith({
@@ -381,6 +384,8 @@ export const createApis = async (ctx) => {
   const dryRunLogger = ctx.logger.child('dryRun')
   const dryRun = dryRunWith({
     ...sharedDeps(dryRunLogger),
+    setTimeout,
+    clearTimeout,
     loadMessageMeta: AoSuClient.loadMessageMetaWith({ fetch: ctx.fetch, logger: dryRunLogger }),
     /**
      * Dry-runs use a separate worker thread pool, so as to not block

--- a/servers/cu/src/domain/api/dryRun.js
+++ b/servers/cu/src/domain/api/dryRun.js
@@ -1,6 +1,6 @@
 import { Readable } from 'node:stream'
-import { omit } from 'ramda'
-import { Resolved, of } from 'hyper-async'
+import { omit, pick } from 'ramda'
+import { Rejected, Resolved, of } from 'hyper-async'
 
 import { loadMessageMetaWith } from '../lib/loadMessageMeta.js'
 import { evaluateWith } from '../lib/evaluate.js'
@@ -8,6 +8,39 @@ import { messageSchema } from '../model.js'
 import { loadModuleWith } from '../lib/loadModule.js'
 import { mapFrom } from '../utils.js'
 import { readStateWith } from './readState.js'
+
+const DEFAULT_MAX_PROCESS_AGE = 2000
+/**
+ * TODO: should this be an effect or shared util?
+ * just keeping here for sake of locality for now
+ */
+const TtlCache = ({ setTimeout, clearTimeout }) => {
+  const cache = {
+    data: new Map(),
+    timers: new Map(),
+    set: (k, v, ttl) => {
+      if (cache.timers.has(k)) clearTimeout(cache.timers.get(k))
+      const t = setTimeout(() => cache.delete(k), ttl)
+      t.unref()
+      cache.timers.set(k, t)
+      cache.data.set(k, v)
+    },
+    get: k => cache.data.get(k),
+    has: k => cache.data.has(k),
+    delete: k => {
+      if (cache.timers.has(k)) clearTimeout(cache.timers.get(k))
+      cache.timers.delete(k)
+      return cache.data.delete(k)
+    },
+    clear: () => {
+      cache.data.clear()
+      for (const v of cache.timers.values()) clearTimeout(v)
+      cache.timers.clear()
+    }
+  }
+
+  return cache
+}
 
 /**
  * @typedef Env
@@ -25,6 +58,7 @@ import { readStateWith } from './readState.js'
  * @returns {ReadResult}
  */
 export function dryRunWith (env) {
+  const logger = env.logger
   const loadMessageMeta = loadMessageMetaWith(env)
   const loadModule = loadModuleWith(env)
   const readState = readStateWith(env)
@@ -37,30 +71,48 @@ export function dryRunWith (env) {
     loadEvaluator: env.loadDryRunEvaluator
   })
 
-  return ({ processId, messageTxId, dryRun }) => {
-    return of({ messageTxId })
-      .chain(({ messageTxId }) => {
-        /**
-         * Load the metadata associated with the messageId ie.
-         * it's timestamp and ordinate, so readState can evaluate
-         * up to that point (if it hasn't already)
-         */
-        if (messageTxId) return loadMessageMeta({ processId, messageTxId })
+  const readStateCache = TtlCache(env)
 
+  function loadMessageCtx ({ messageTxId, processId }) {
+    /**
+     * Load the metadata associated with the messageId ie.
+     * it's timestamp and ordinate, so readState can evaluate
+     * up to that point (if it hasn't already)
+     */
+    if (messageTxId) return loadMessageMeta({ processId, messageTxId })
+
+    /**
+     * No messageTxId provided so evaluate up to latest
+     */
+    return Resolved({
+      processId,
+      timestamp: undefined,
+      nonce: undefined
+    })
+  }
+
+  function ensureProcessLoaded ({ maxProcessAge }) {
+    return (ctx) => of(ctx)
+      .chain((ctx) => {
         /**
-         * No messageTxId provided so evaluate up to latest
+         * Check to see whether process memory from a previous readState,
+         * executed by a previous dryRun, can be used to perform this dryRun
          */
-        return Resolved({
-          processId,
-          to: undefined,
-          ordinate: undefined
-        })
+        const cached = readStateCache.get(ctx.processId)
+
+        if (cached && new Date().getTime() - cached.age <= maxProcessAge) {
+          logger.debug(
+            'Using recently cached process memory for dry-run to process "%s": "%j"',
+            ctx.processId,
+            pick(['from', 'ordinate', 'fromBlockHeight', 'fromCron'], cached.ctx)
+          )
+          return Resolved(cached.ctx)
+        }
+
+        return Rejected(ctx)
       })
-      /**
-       * Read up to the specified 'to', or latest
-       */
-      .chain((res) =>
-        readState({
+      .bichain(
+        (res) => readState({
           processId: res.processId,
           to: res.timestamp,
           /**
@@ -75,89 +127,104 @@ export function dryRunWith (env) {
            */
           cron: undefined,
           needsOnlyMemory: true
-        })
+        }).map((res) => {
+          const cached = { age: new Date().getTime(), ctx: res }
+          /**
+           * Cache the readState. Since we are not copying ctx,
+           * this should have a fairly minimal footprint, only adding
+           * the overhead of maintaining the map, timers, for the specified
+           * age
+           */
+          readStateCache.set(res.id, cached, 4000)
+          return res
+        }),
+        Resolved
       )
+  }
+
+  function ensureModuleLoaded (ctx) {
+    /**
+     * If a cached evaluation was found and immediately returned,
+     * then we will have not loaded the module and attached it to ctx.
+     *
+     * So we check if ctx.module is set, and load the Module if not.
+     *
+     * This check will prevent us from unnecessarily loading the module
+     * from Arweave, twice.
+     */
+    if (!ctx.moduleId) return loadModule(ctx)
+
+    /**
+     * The module was loaded by readState, as part of evaluation,
+     * so no need to load it again. Just reuse it
+     */
+    return Resolved(ctx)
+  }
+
+  return ({ processId, messageTxId, maxProcessAge = DEFAULT_MAX_PROCESS_AGE, dryRun }) => {
+    return of({ processId, messageTxId })
+      .chain(loadMessageCtx)
+      .chain(ensureProcessLoaded({ maxProcessAge }))
+      .chain(ensureModuleLoaded)
       /**
        * We've read up to 'to', now inject the dry-run message
        *
        * { id, owner, tags, output: { Memory, Error, Messages, Spawns, Output } }
        */
-      .chain((readStateRes) => {
-        return of(readStateRes)
-          .chain((ctx) => {
+      .chain((ctx) => {
+        async function * dryRunMessage () {
+          /**
+           * Dry run messages are not signed, and therefore
+           * will not have a verifiable Id, Signature, Owner, etc.
+           *
+           * NOTE:
+           * Dry Run messages are not signed, therefore not verifiable.
+           *
+           * This is generally okay, because dry-run message evaluations
+           * are Read-Only and not persisted -- the primary use-case for Dry Run is to enable
+           * retrieving a view of a processes state, without having to send a bonafide message.
+           *
+           * However, we should keep in mind the implications. One implication is that spoofing
+           * Owner or other fields on a Dry-Run message (unverifiable context) exposes a way to
+           * "poke and prod" a process modules for vulnerabilities.
+           */
+          yield messageSchema.parse({
             /**
-             * If a cached evaluation was found and immediately returned,
-             * then we will have not loaded the module and attached it to ctx.
-             *
-             * So we check if ctx.module is set, and load the Module if not.
-             *
-             * This check will prevent us from unnecessarily loading the module
-             * from Arweave, twice.
+             * Don't save the dryRun message
              */
-            if (!ctx.moduleId) return loadModule(ctx)
-
-            /**
-             * The module was loaded by readState, as part of evaluation,
-             * so no need to load it again. Just reuse it
-             */
-            return Resolved(ctx)
-          })
-          .chain((ctx) => {
-            async function * dryRunMessage () {
+            noSave: true,
+            deepHash: undefined,
+            cron: undefined,
+            ordinate: ctx.ordinate,
+            name: 'Dry Run Message',
+            message: {
               /**
-               * Dry run messages are not signed, and therefore
-               * will not have a verifiable Id, Signature, Owner, etc.
+               * We default timestamp and block-height using
+               * the current evaluation.
                *
-               * NOTE:
-               * Dry Run messages are not signed, therefore not verifiable.
-               *
-               * This is generally okay, because dry-run message evaluations
-               * are Read-Only and not persisted -- the primary use-case for Dry Run is to enable
-               * retrieving a view of a processes state, without having to send a bonafide message.
-               *
-               * However, we should keep in mind the implications. One implication is that spoofing
-               * Owner or other fields on a Dry-Run message (unverifiable context) exposes a way to
-               * "poke and prod" a process modules for vulnerabilities.
+               * The Dry-Run message can overwrite them
                */
-              yield messageSchema.parse({
-                /**
-                 * Don't save the dryRun message
-                 */
-                noSave: true,
-                deepHash: undefined,
-                cron: undefined,
-                ordinate: ctx.ordinate,
-                name: 'Dry Run Message',
-                message: {
-                  /**
-                   * We default timestamp and block-height using
-                   * the current evaluation.
-                   *
-                   * The Dry-Run message can overwrite them
-                   */
-                  Timestamp: ctx.from,
-                  'Block-Height': ctx.fromBlockHeight,
-                  Cron: false,
-                  Target: processId,
-                  ...dryRun,
-                  From: mapFrom({ tags: dryRun.Tags, owner: dryRun.Owner }),
-                  'Read-Only': true
-                },
-                AoGlobal: {
-                  Process: { Id: processId, Owner: ctx.owner, Tags: ctx.tags },
-                  Module: { Id: ctx.moduleId, Owner: ctx.moduleOwner, Tags: ctx.moduleTags }
-                }
-              })
+              Timestamp: ctx.from,
+              'Block-Height': ctx.fromBlockHeight,
+              Cron: false,
+              Target: processId,
+              ...dryRun,
+              From: mapFrom({ tags: dryRun.Tags, owner: dryRun.Owner }),
+              'Read-Only': true
+            },
+            AoGlobal: {
+              Process: { Id: processId, Owner: ctx.owner, Tags: ctx.tags },
+              Module: { Id: ctx.moduleId, Owner: ctx.moduleOwner, Tags: ctx.moduleTags }
             }
-
-            /**
-             * Pass a messages stream to evaluate that only emits the single dry-run
-             * message and then completes
-             */
-            return evaluate({ ...ctx, dryRun: true, messages: Readable.from(dryRunMessage()) })
           })
+        }
+
+        /**
+         * Pass a messages stream to evaluate that only emits the single dry-run
+         * message and then completes
+         */
+        return evaluate({ ...ctx, dryRun: true, messages: Readable.from(dryRunMessage()) })
       })
-      .map((res) => res.output)
-      .map(omit(['Memory']))
+      .map((res) => omit(['Memory'], res.output))
   }
 }

--- a/servers/cu/src/domain/api/dryRun.js
+++ b/servers/cu/src/domain/api/dryRun.js
@@ -74,14 +74,7 @@ export function dryRunWith (env) {
            * So we explicitly set cron to undefined, for posterity
            */
           cron: undefined,
-          /**
-           * If we are evaluating up to a specific message, as indicated by
-           * the presence of messageTxId, then we make sure we get an exact match.
-           *
-           * Otherwise, we are evaluating up to the latest
-           */
-          exact: !!messageTxId,
-          needsMemory: true
+          needsOnlyMemory: true
         })
       )
       /**

--- a/servers/cu/src/domain/api/readResult.js
+++ b/servers/cu/src/domain/api/readResult.js
@@ -41,10 +41,7 @@ export function readResultWith (env) {
          * So we explicitly set cron to undefined, for posterity
          */
         cron: undefined,
-        /**
-         * We want an exact match to this messages evaluation
-         */
-        exact: true
+        needsOnlyMemory: false
       }))
       .map((res) => res.output)
       .map(omit(['Memory']))

--- a/servers/cu/src/domain/lib/chainEvaluation.js
+++ b/servers/cu/src/domain/lib/chainEvaluation.js
@@ -1,30 +1,9 @@
-import { Rejected, Resolved, fromPromise, of } from 'hyper-async'
-import { identity, join, pick } from 'ramda'
+import { Rejected, Resolved, fromPromise } from 'hyper-async'
+import { identity, pick } from 'ramda'
 import AsyncLock from 'async-lock'
 
 import { findEvaluationSchema } from '../dal.js'
 import { findPendingForProcessBeforeWith, isLaterThan } from '../utils.js'
-
-/**
- * We will maintain a Map of currently executing readState calls.
- *
- * If another request comes in to invoke a readState that is already
- * pending, then we will just return that Async instead of spinning up a new readState.
- *
- * TODO: this should perhaps be moved to the top of readState and injected into chainEvaluation
- *
- * @type {Map<string, { startTime: Date, pending: Promise<any> }}
- */
-export const pendingReadState = new Map()
-const pendingKey = join(',')
-const removePendingReadState = (key) => (res) => {
-  pendingReadState.delete(key)
-  return res
-}
-
-export const pendingReadStates = () => Object.fromEntries(pendingReadState.entries())
-
-const findPendingForProcessBefore = findPendingForProcessBeforeWith(pendingReadState)
 
 const chainLock = new AsyncLock({ maxPending: Number.MAX_SAFE_INTEGER })
 
@@ -38,7 +17,7 @@ function loadLatestEvaluationWith ({ findEvaluation, findLatestProcessMemory, lo
      * We also need the Memory for the evaluation,
      * we need to either fetch from cache or perform an evaluation
      */
-    if (ctx.needsMemory) return Rejected(ctx)
+    if (ctx.needsOnlyMemory) return Rejected(ctx)
 
     return findEvaluation({
       processId: ctx.id,
@@ -127,177 +106,144 @@ export function chainEvaluationWith (env) {
 
   const loadLatestEvaluation = loadLatestEvaluationWith(env)
 
+  const pendingReadState = env.pendingReadState
+  const fromPendingKey = env.fromPendingKey
+  const findPendingForProcessBefore = findPendingForProcessBeforeWith(pendingReadState)
+
   /**
    * Check whether any evaluation chaining can be performed,
    * potentially reducing duplicated work.
    *
-   * Depending on the pending readState operations,
-   * this Async could either immediately resolve (nothing to chain on), or resolve
-   * only once another eval stream is complete.
-   *
-   * When the latter happens, this eval stream is said to be "chainedTo"
-   * the pending evaluation stream.
+   * Find an exact match to the evaluation requesting to be performed (a cached eval)
+   * or return a cache entry to be chainedTo
    */
-  return ({ processId, to, ordinate, cron, exact, needsMemory, next }) => {
-    const key = pendingKey([processId, to, ordinate, cron, exact, needsMemory])
-
-    return of()
+  return ({ pendingKey: key, processId, to, ordinate, cron, needsOnlyMemory }) => {
+    /**
+     * LOCK CRITICAL SECTION:
+     *
+     * determine what to do with the incoming readState:
+     * - chain it to an existing evaluation stream
+     * - dedupe it, due to an identicial evaluation stream already executing
+     * - start it up as a brand new evaluation stream
+     *
+     * This check requires acquisition of a lock, to avoid race conditions from multiple
+     * incoming readStates asynchronously determining whether or not to chain
+     */
+    return fromPromise(() => chainLock.acquire(processId, async () => {
       /**
-       * LOCK CRITICAL SECTION:
-       *
-       * determine what to do with the incoming readState:
-       * - chain it to an existing evaluation stream
-       * - dedupe it, due to an identicial evaluation stream already executing
-       * - start it up as a brand new evaluation stream
-       *
-       * This check requires acquisition of a lock, to avoid race conditions from multiple
-       * incoming readStates asynchronously determining whether or not to chain
+       * There is already an exact instance of the readState already pending,
+       * so simply return the entry, and no new work need to be performed
        */
-      .chain(fromPromise(() => chainLock.acquire(processId, async () =>
-        Promise.resolve(key)
-          .then(async (key) => {
-            /**
-             * There is already an exact instance of the readState already pending,
-             * so simply return the entry, and no new work need to be performed
-             */
-            if (pendingReadState.has(key)) return [false, pendingReadState.get(key)]
+      if (pendingReadState.has(key)) return [false, pendingReadState.get(key)]
 
+      /**
+       * Check if the starting point found in caching layers
+       * is earlier than a pending eval stream, and simply
+       * chain off the pending eval stream if so.
+       *
+       * Otherwise, we start a separate evaluation stream using the
+       * starting point from the cache.
+       *
+       * This will help ensure a request to evaluate an old message
+       * does not cause delays on evaluations of newer messages that may
+       * have later checkpoints available on chain to "hot start" from.
+       *
+       * By default, there is nothing to chain off of, so just resolve immediately
+       */
+      let newEntry = {
+        startTime: new Date(),
+        chainedTo: undefined,
+        pending: Promise.resolve()
+      }
+
+      const pendingForProcessBefore = findPendingForProcessBefore({ processId, timestamp: to })
+      /**
+       * No pending evaluation stream was found, so there is no reason to check the process
+       * memory cache for an entry and then to compare it to the pending evalaution stream,
+       * in order to determine the optimal chaining strategy.
+       *
+       * This will result in an evaluation stream being immediately spun up
+       * with no chaining
+       */
+      if (!pendingForProcessBefore) return [true, newEntry]
+
+      return loadLatestEvaluation({ id: processId, to, ordinate, cron, needsOnlyMemory })
+        .toPromise()
+        .then((res) => {
+          /**
+           * The exact evaluation (identified by its input messages timestamp)
+           * was found in the cache, so just return it.
+           *
+           * This results in no new evaluation stream being performed, as the work
+           * has already been performed and cached.
+           *
+           * An evaluation stream will ultimately return a { result } containing
+           * the message result. so since we've found the output
+           * cached, we simply set { result } to the cached
+           * evaluation output, to match the shape.
+           */
+          if (res.exact) return [false, { pending: Promise.resolve({ ...res, output: res.result }) }]
+
+          const [pendingKey, { pending, chainedTo }] = pendingForProcessBefore
+          const [, pTo, pOrdinate, pCron] = fromPendingKey(pendingKey)
+
+          /**
+           * If the incoming eval stream will be cold started,
+           * then we chain it to ANY pending eval stream. This is to
+           * prevent multiple cold starts of the same process. This could mean that, in some cases,
+           * a message eval from a cold start could "wait" unnecessarily longer (ie. the pending is evaluating
+           * up to a much later message than the one being requested). To that, there are two points:
+           *
+           * 1. the request to eval an old message ought to be dispreferred anyway
+           * 2. the old message will be in the CUs result cache, and so immediately
+           * be returned to the client, without starting another eval stream, a boon for the CU.
+           *
+           * Regardless, this branch should only trigger when there is a process with a lengthy eval stream from a cold start,
+           * and most of the time cold starts happen only for new processes, whose message history is short, and typically cheaper
+           * to compute.
+           *
+           * ---
+           *
+           * Alternatively (not a cold start), we must compare the actual chronology
+           * between the loaded latest evaluation and the found
+           * pending readState, and decide whether it is advantageous to chain
+           */
+          const isPendingLaterThanCached = res.isColdStart || (!!res.from && isLaterThan(
+            { timestamp: res.from, ordinate: res.ordinate, cron: res.fromCron },
+            { timestamp: pTo, ordinate: pOrdinate, cron: pCron }
+          ))
+
+          if (isPendingLaterThanCached) {
+            env.logger(
+              'found pending readState at "%j" to chain to, later than cached %j, for incoming readState "%s"',
+              { key: pendingKey, chainedTo },
+              !res.isColdStart
+                ? { timestamp: res.from, ordinate: res.ordinate, cron: res.fromCron }
+                : { COLD_START: true },
+              key
+            )
             /**
-             * Check if the starting point found in caching layers
-             * is earlier than a pending eval stream, and simply
-             * chain off the pending eval stream if so.
+             * chain off already pending evaluation stream,
+             * indicating it's place in the chain by the
+             * entry's "chainedTo" field.
              *
-             * Otherwise, we start a separate evaluation stream using the
-             * starting point from the cache.
-             *
-             * This will help ensure a request to evaluate an old message
-             * does not cause delays on evaluations of newer messages that may
-             * have later checkpoints available on chain to "hot start" from.
-             *
-             * By default, there is nothing to chain off of, so just resolve immediately
+             * The result is a set of trees where each pending evaluation stream
+             * may have a parent evaluation stream that it is waiting for to complete
+             * and potentially many children evaluation streams itself
              */
-            let newEntry = {
+            newEntry = {
               startTime: new Date(),
-              chainedTo: undefined,
-              pending: Promise.resolve()
+              chainedTo: pendingKey,
+              /**
+               * chain off already pending readState
+               * @type {Promise}
+               */
+              pending
             }
+          }
 
-            const pendingForProcessBefore = findPendingForProcessBefore({ processId, timestamp: to })
-            /**
-             * No pending evaluation stream was found, so there is no reason to check the process
-             * memory cache for an entry and then to compare it to the pending evalaution stream,
-             * in order to determine the optimal chaining strategy.
-             *
-             * This will result in an evaluation stream being immediately spun up
-             * with no chaining
-             */
-            if (!pendingForProcessBefore) return [true, newEntry]
-
-            return loadLatestEvaluation({ id: processId, to, ordinate, cron, exact, needsMemory })
-              .toPromise()
-              .then((res) => {
-                /**
-                 * The exact evaluation (identified by its input messages timestamp)
-                 * was found in the cache, so just return it.
-                 *
-                 * This results in no new evaluation stream being performed, as the work
-                 * has already been performed and cached.
-                 *
-                 * An evaluation stream will ultimately return a { result } containing
-                 * the message result. so since we've found the output
-                 * cached, we simply set { result } to the cached
-                 * evaluation output, to match the shape.
-                 */
-                if (res.exact) return [false, { pending: Promise.resolve({ ...res, output: res.result }) }]
-
-                const [pendingKey, { pending, chainedTo }] = pendingForProcessBefore
-                const [, pTo, pOrdinate, pCron] = pendingKey.split(',')
-
-                /**
-                 * If the incoming eval stream will be cold started,
-                 * then we chain it to ANY pending eval stream. This is to
-                 * prevent multiple cold starts of the same process. This could mean that, in some cases,
-                 * a message eval from a cold start could "wait" unnecessarily longer (ie. the pending is evaluating
-                 * up to a much later message than the one being requested). To that, there are two points:
-                 *
-                 * 1. the request to eval an old message ought to be dispreferred anyway
-                 * 2. the old message will be in the CUs result cache, and so immediately
-                 * be returned to the client, without starting another eval stream, a boon for the CU.
-                 *
-                 * Regardless, this branch should only trigger when there is a process with a lengthy eval stream from a cold start,
-                 * and most of the time cold starts happen only for new processes, whose message history is short, and typically cheaper
-                 * to compute.
-                 *
-                 * ---
-                 *
-                 * Alternatively (not a cold start), we must compare the actual chronology
-                 * between the loaded latest evaluation and the found
-                 * pending readState, and decide whether it is advantageous to chain
-                 */
-                const isPendingLaterThanCached = res.isColdStart || (!!res.from && isLaterThan(
-                  { timestamp: res.from, ordinate: res.ordinate, cron: res.fromCron },
-                  { timestamp: pTo, ordinate: pOrdinate, cron: pCron }
-                ))
-
-                if (isPendingLaterThanCached) {
-                  env.logger(
-                    'found pending readState at "%j" to chain to, later than cached %j, for incoming readState "%s"',
-                    { key: pendingKey, chainedTo },
-                    !res.isColdStart
-                      ? { timestamp: res.from, ordinate: res.ordinate, cron: res.fromCron }
-                      : { COLD_START: true },
-                    key
-                  )
-                  /**
-                   * chain off already pending evaluation stream,
-                   * indicating it's place in the chain by the
-                   * entry's "chainedTo" field.
-                   *
-                   * The result is a set of trees where each pending evaluation stream
-                   * may have a parent evaluation stream that it is waiting for to complete
-                   * and potentially many children evaluation streams itself
-                   */
-                  newEntry = {
-                    startTime: new Date(),
-                    chainedTo: pendingKey,
-                    /**
-                     * chain off already pending readState
-                     * @type {Promise}
-                     */
-                    pending
-                  }
-                }
-
-                return [true, newEntry]
-              })
-          })
-          .then(([isNewEntry, res]) => {
-            /**
-             * A cached result or an exact pending readState was found
-             * so just return it
-             */
-            if (!isNewEntry) return res
-
-            /**
-             * New evaluations must be performed, so place it
-             * in the map of pendingReadStates, and chain the new work to be performed
-             * off of the pending work, then clean up by removing itself from the map
-             */
-            const newEntry = {
-              startTime: res.startTime,
-              chainedTo: res.chainedTo,
-              pending: res.pending
-                .then(() => next.toPromise())
-                .finally(removePendingReadState(key))
-            }
-            pendingReadState.set(key, newEntry)
-
-            return newEntry
-          })
-      )))
-      /**
-       * LOCK RELEASED
-       */
-      .chain(fromPromise((res) => res.pending))
+          return [true, newEntry]
+        })
+    }))()
   }
 }

--- a/servers/cu/src/domain/lib/loadProcess.js
+++ b/servers/cu/src/domain/lib/loadProcess.js
@@ -61,7 +61,7 @@ function loadLatestEvaluationWith ({ findEvaluation, findLatestProcessMemory, sa
      * We also need the Memory for the evaluation,
      * we need to either fetch from cache or perform an evaluation
      */
-    if (ctx.needsMemory) return Rejected(ctx)
+    if (ctx.needsOnlyMemory) return Rejected(ctx)
 
     return findEvaluation({
       processId: ctx.id,


### PR DESCRIPTION
Closes #984 

This also adds an optimization downstream from chaining evaluation streams: if there is overlap between chained eval streams, which can happen if many messages are sent a process and requested from the CU close together (the result calls may arrive out of order to the CU), then the CU will more likely serve that overlap from the evaluation cache rather than spin up another evaluation stream. This should help reduce resource contention for messages that have already been evaluated.

The majority of the diff in `dryRun` is just rejigging the Async chain to be more declarative. There is a bit more going on in the steps and it's more kosher to use a declarative style, so that the intent is not lost in the implementation details.