### PR TITLE
chore(cu): update ao-loader and weavedrive dependencies to newest versions

### DIFF
--- a/servers/cu/package-lock.json
+++ b/servers/cu/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@fastify/middie": "^8.3.1",
-        "@permaweb/ao-loader": "^0.0.35",
+        "@permaweb/ao-loader": "^0.0.37",
         "@permaweb/ao-scheduler-utils": "^0.0.19",
-        "@permaweb/weavedrive": "^0.0.6",
+        "@permaweb/weavedrive": "^0.0.8",
         "arweave": "^1.15.1",
         "async-lock": "^1.4.1",
         "better-sqlite3": "^11.1.2",
@@ -162,9 +162,12 @@
       }
     },
     "node_modules/@permaweb/ao-loader": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@permaweb/ao-loader/-/ao-loader-0.0.35.tgz",
-      "integrity": "sha512-vgDs2PYJqiKYnEVHYccP5VOjc+YkcinYW8YQa53fxYzy4D/KEWwiMnocz3zNb7L+6dKNT6EghHft7xMcs01WMQ==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@permaweb/ao-loader/-/ao-loader-0.0.37.tgz",
+      "integrity": "sha512-lOGFlDzmlPUgrHwvUhvRUaoUatYL5CEi7OxiaPzgNURTNNi72DkxcjUB2ZgcJ2A0zQQhTmRl3++PFeygoHgvTA==",
+      "dependencies": {
+        "@permaweb/wasm-metering": "^0.2.2"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -188,10 +191,39 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/@permaweb/wasm-json-toolkit": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@permaweb/wasm-json-toolkit/-/wasm-json-toolkit-0.2.9.tgz",
+      "integrity": "sha512-CGCeUwS+UeqUdvORiyG0LykkQXLTwS5TWc590CUkDfOYyBUSPv8pse0sJStvTC9LKAzuNx3ELBvmqHCI4muUAA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "buffer-pipe": "0.0.3",
+        "leb128": "0.0.4",
+        "safe-buffer": "^5.1.2"
+      },
+      "bin": {
+        "json2wasm": "bin/json2wasm",
+        "wasm2json": "bin/wasm2json"
+      }
+    },
+    "node_modules/@permaweb/wasm-metering": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@permaweb/wasm-metering/-/wasm-metering-0.2.2.tgz",
+      "integrity": "sha512-xM2MbPkHc4rzhTR6VH5eXtfC+liaYSuNCa0kPRaqSZO2gr1SirJWnzUBDa5VOfTBTgIlIVv5RW+Mkbt/VuK+oA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@permaweb/wasm-json-toolkit": "^0.2.9",
+        "leb128": "^0.0.4"
+      },
+      "bin": {
+        "wasm-meter": "bin/wasm-meter"
+      }
+    },
     "node_modules/@permaweb/weavedrive": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@permaweb/weavedrive/-/weavedrive-0.0.6.tgz",
-      "integrity": "sha512-ZlL+iZcsKlaublvILf1eUbfAM7xrabWR0NSzKCFcdgWYV5yGndQuIy6wEaU4zNxTzUrOMvVYTkLg083RukO19g=="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@permaweb/weavedrive/-/weavedrive-0.0.8.tgz",
+      "integrity": "sha512-NANYoZewSpIR9dpcj86Lzqiq3y2dcOr+8PDuribGkpqWV6Z7tbJGidm3WnHnwo8/5k8C3RDSBZpX87PdVg8z6g==",
+      "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -479,6 +511,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-pipe": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.3.tgz",
+      "integrity": "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/bytes": {
@@ -1071,6 +1112,25 @@
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
+    },
+    "node_modules/leb128": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/leb128/-/leb128-0.0.4.tgz",
+      "integrity": "sha512-2zejk0fCIgY8RVcc/KzvyfpDio5Oo8HgPZmkrOmdwmbk0KpKpgD+JKwikxKk8cZYkANIhwHK50SNukkCm3XkCQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "buffer-pipe": "0.0.0"
+      }
+    },
+    "node_modules/leb128/node_modules/buffer-pipe": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.0.tgz",
+      "integrity": "sha512-PvKbsvQOH4dcUyUEvQQSs3CIkkuPcOHt3gKnXwf4HsPKFDxSN7bkmICVIWgOmW/jx/fAEGGn4mIayIJPLs7G8g==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      }
     },
     "node_modules/light-my-request": {
       "version": "5.11.0",
@@ -2250,9 +2310,12 @@
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w=="
     },
     "@permaweb/ao-loader": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@permaweb/ao-loader/-/ao-loader-0.0.35.tgz",
-      "integrity": "sha512-vgDs2PYJqiKYnEVHYccP5VOjc+YkcinYW8YQa53fxYzy4D/KEWwiMnocz3zNb7L+6dKNT6EghHft7xMcs01WMQ=="
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@permaweb/ao-loader/-/ao-loader-0.0.37.tgz",
+      "integrity": "sha512-lOGFlDzmlPUgrHwvUhvRUaoUatYL5CEi7OxiaPzgNURTNNi72DkxcjUB2ZgcJ2A0zQQhTmRl3++PFeygoHgvTA==",
+      "requires": {
+        "@permaweb/wasm-metering": "^0.2.2"
+      }
     },
     "@permaweb/ao-scheduler-utils": {
       "version": "0.0.19",
@@ -2271,10 +2334,29 @@
         }
       }
     },
+    "@permaweb/wasm-json-toolkit": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@permaweb/wasm-json-toolkit/-/wasm-json-toolkit-0.2.9.tgz",
+      "integrity": "sha512-CGCeUwS+UeqUdvORiyG0LykkQXLTwS5TWc590CUkDfOYyBUSPv8pse0sJStvTC9LKAzuNx3ELBvmqHCI4muUAA==",
+      "requires": {
+        "buffer-pipe": "0.0.3",
+        "leb128": "0.0.4",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "@permaweb/wasm-metering": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@permaweb/wasm-metering/-/wasm-metering-0.2.2.tgz",
+      "integrity": "sha512-xM2MbPkHc4rzhTR6VH5eXtfC+liaYSuNCa0kPRaqSZO2gr1SirJWnzUBDa5VOfTBTgIlIVv5RW+Mkbt/VuK+oA==",
+      "requires": {
+        "@permaweb/wasm-json-toolkit": "^0.2.9",
+        "leb128": "^0.0.4"
+      }
+    },
     "@permaweb/weavedrive": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@permaweb/weavedrive/-/weavedrive-0.0.6.tgz",
-      "integrity": "sha512-ZlL+iZcsKlaublvILf1eUbfAM7xrabWR0NSzKCFcdgWYV5yGndQuIy6wEaU4zNxTzUrOMvVYTkLg083RukO19g=="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@permaweb/weavedrive/-/weavedrive-0.0.8.tgz",
+      "integrity": "sha512-NANYoZewSpIR9dpcj86Lzqiq3y2dcOr+8PDuribGkpqWV6Z7tbJGidm3WnHnwo8/5k8C3RDSBZpX87PdVg8z6g=="
     },
     "@types/triple-beam": {
       "version": "1.3.5",
@@ -2491,6 +2573,14 @@
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-pipe": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.3.tgz",
+      "integrity": "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA==",
+      "requires": {
+        "safe-buffer": "^5.1.2"
       }
     },
     "bytes": {
@@ -2931,6 +3021,25 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
+    "leb128": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/leb128/-/leb128-0.0.4.tgz",
+      "integrity": "sha512-2zejk0fCIgY8RVcc/KzvyfpDio5Oo8HgPZmkrOmdwmbk0KpKpgD+JKwikxKk8cZYkANIhwHK50SNukkCm3XkCQ==",
+      "requires": {
+        "bn.js": "^4.11.6",
+        "buffer-pipe": "0.0.0"
+      },
+      "dependencies": {
+        "buffer-pipe": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.0.tgz",
+          "integrity": "sha512-PvKbsvQOH4dcUyUEvQQSs3CIkkuPcOHt3gKnXwf4HsPKFDxSN7bkmICVIWgOmW/jx/fAEGGn4mIayIJPLs7G8g==",
+          "requires": {
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
     },
     "light-my-request": {
       "version": "5.11.0",

--- a/servers/cu/package.json
+++ b/servers/cu/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@fastify/middie": "^8.3.1",
-    "@permaweb/ao-loader": "^0.0.35",
+    "@permaweb/ao-loader": "^0.0.37",
     "@permaweb/ao-scheduler-utils": "^0.0.19",
-    "@permaweb/weavedrive": "^0.0.6",
+    "@permaweb/weavedrive": "^0.0.8",
     "arweave": "^1.15.1",
     "async-lock": "^1.4.1",
     "better-sqlite3": "^11.1.2",


### PR DESCRIPTION
## 📦 Updated `package.json` Dependencies

This PR updates the dependencies in the CU `package.json`:

1. **@permaweb/ao-loader**: `0.0.35` → `0.0.37`
2. **@permaweb/weavedrive**: `0.0.6` → `0.0.8`

---
### 🔍 Information

- The updated **AO-Loader** now includes the ability to inject metering for gas usage determination.
- The new Weavedrive update includes support for the bootloader and reading layer2 dataItems.
