### PR TITLE
perf(loader): allow skipping outputting memory

### DIFF
--- a/loader/src/index.cjs
+++ b/loader/src/index.cjs
@@ -64,10 +64,16 @@ const metering = require('@permaweb/wasm-metering')
  */
 
 /**
+ * @typedef HandleOptions
+ * @property {boolean} [outputMemory=true]
+ */
+
+/**
  * @callback handleFunction
  * @param {ArrayBuffer | null} buffer
  * @param {Message} msg
  * @param {Environment} env
+ * @param {HandleOptions} [options]
  * @returns {Promise<HandleResponse>}
  */
 
@@ -156,7 +162,8 @@ module.exports = async function (binary, options) {
     WebAssembly.instantiate = originalInstantiate;
   }
 
-  return async (buffer, msg, env) => {
+  return async (buffer, msg, env, opts) => {
+    const outputMemory = opts?.outputMemory ?? true
 
     const originalRandom = Math.random
     // const OriginalDate = Date
@@ -195,7 +202,9 @@ module.exports = async function (binary, options) {
       /** end unmock */
 
       return {
-        Memory: instance.HEAPU8.slice(),
+        Memory: outputMemory
+          ? instance.HEAPU8.slice()
+          : null,
         Error: response.Error,
         Output: response.Output,
         Messages: response.Messages,

--- a/loader/test/handle.test.js
+++ b/loader/test/handle.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test'
+import * as assert from 'node:assert'
+import fs from 'fs'
+
+const MODULE_PATH = process.env.MODULE_PATH || '../src/index.cjs'
+
+const env = {
+  Process: {
+    Id: 'AOS',
+    Owner: 'FOOBAR',
+    Tags: [
+      { name: 'Name', value: 'Thomas' }
+    ]
+  }
+}
+const msg = (cmd) => ({
+  Target: 'AOS',
+  Owner: 'FOOBAR',
+  'Block-Height': '1000',
+  Id: '1234xyxfoo',
+  Module: 'WOOPAWOOPA',
+  Tags: [
+    { name: 'Action', value: 'Eval' }
+  ],
+  Data: cmd
+})
+
+const { default: AoLoader } = await import(MODULE_PATH)
+const wasm = fs.readFileSync('./test/aos/process.wasm')
+
+test('do return memory based on outputMemory option', async () => {
+  const handle = await AoLoader(wasm, { format: 'wasm32-unknown-emscripten2' })
+  const testMsg = msg('X = 1')
+
+  const result1 = await handle(null, testMsg, env, { outputMemory: true })
+  assert.ok(result1.Memory)
+
+  const result2 = await handle(result1.Memory, testMsg, env, { outputMemory: false })
+  assert.equal(result2.Memory, null)
+})


### PR DESCRIPTION
Add `outputMemory` option (default true) -- useful as this can be very expensive in a loop