### PR TITLE
chore(cu/loader): Integrate WASM Metering into CU and Loader 

### DIFF
--- a/loader/src/index.cjs
+++ b/loader/src/index.cjs
@@ -113,10 +113,15 @@ WebAssembly.compileStreaming = async function (source, importObject = {}) {
   // Read the response and convert it to an ArrayBuffer
   const arrayBuffer = await source.arrayBuffer();
 
-  let meterType = importObject.format.startsWith("wasm32") ? "i32" : "i64";
-
   // Convert ArrayBuffer to Uint8Array for metering compatibility
   const nodeBuffer = Buffer.from(arrayBuffer);
+
+  if(options.format === "wasm32-unknown-emscripten" || options.format === "wasm32-unknown-emscripten2" || options.format === "wasm32-unknown-emscripten3") {
+    return WebAssembly.compile(nodeBuffer);
+  }
+
+  let meterType = importObject.format.startsWith("wasm32") ? "i32" : "i64";
+
 
   // Apply metering with the Uint8Array buffer
   const meteredView = metering.meterWASM(nodeBuffer, { meterType });

--- a/loader/src/index.cjs
+++ b/loader/src/index.cjs
@@ -116,12 +116,11 @@ WebAssembly.compileStreaming = async function (source, importObject = {}) {
   // Convert ArrayBuffer to Uint8Array for metering compatibility
   const nodeBuffer = Buffer.from(arrayBuffer);
 
-  if(options.format === "wasm32-unknown-emscripten" || options.format === "wasm32-unknown-emscripten2" || options.format === "wasm32-unknown-emscripten3") {
+  if(importObject.format === "wasm32-unknown-emscripten" || importObject.format === "wasm32-unknown-emscripten2" || importObject.format === "wasm32-unknown-emscripten3") {
     return WebAssembly.compile(nodeBuffer);
   }
 
   let meterType = importObject.format.startsWith("wasm32") ? "i32" : "i64";
-
 
   // Apply metering with the Uint8Array buffer
   const meteredView = metering.meterWASM(nodeBuffer, { meterType });
@@ -129,7 +128,6 @@ WebAssembly.compileStreaming = async function (source, importObject = {}) {
   // const meteredResponse = new Response(meteredBuffer, { headers: { 'Content-Type': 'application/wasm' } });
   return  WebAssembly.compile(meteredView.buffer);
 };
-
 
 module.exports = async function (binary, options) {
   let instance = null

--- a/loader/src/index.cjs
+++ b/loader/src/index.cjs
@@ -91,12 +91,47 @@ const metering = require('@permaweb/wasm-metering')
  * @param {Options} [options]
  * @returns {Promise<handleFunction>}
  */
+
+/*
+ * Custom WebAssembly.compileStreaming Implementation with WASM Metering
+ *
+ * This implementation overrides WebAssembly.compileStreaming to add metering 
+ * to WebAssembly binaries. Metering enables tracking of resource usage (e.g., 
+ * CPU or memory) within the WebAssembly runtime, which is critical for monitoring 
+ * performance and managing resource allocation in constrained environments.
+ *
+ * Why Metering?
+ * The CU (Compute Unit) calls WebAssembly.compileStreaming to execute WebAssembly 
+ * modules, but to centralize and streamline metering, we handle it here in the loader 
+ * instead of within each CU instance. By integrating metering directly into the 
+ * loader, we ensure that all WebAssembly binaries are metered consistently across 
+ * different CUs, reducing redundancy and enhancing modularity.
+ */
+
+// Override WebAssembly.compileStreaming to apply metering
+WebAssembly.compileStreaming = async function (source, importObject = {}) {
+  // Read the response and convert it to an ArrayBuffer
+  const arrayBuffer = await source.arrayBuffer();
+
+  let meterType = importObject.format.startsWith("wasm32") ? "i32" : "i64";
+
+  // Convert ArrayBuffer to Uint8Array for metering compatibility
+  const nodeBuffer = Buffer.from(arrayBuffer);
+
+  // Apply metering with the Uint8Array buffer
+  const meteredView = metering.meterWASM(nodeBuffer, { meterType });
+
+  // const meteredResponse = new Response(meteredBuffer, { headers: { 'Content-Type': 'application/wasm' } });
+  return  WebAssembly.compile(meteredView.buffer);
+};
+
+
 module.exports = async function (binary, options) {
   let instance = null
   let doHandle = null
 
   let meterType = options.format.startsWith("wasm32") ? "i32" : "i64";
-  const originalInstantiate = WebAssembly.instantiate;
+
 
   if (options === null) {
     options = { format: 'wasm32-unknown-emscripten' }
@@ -110,14 +145,9 @@ module.exports = async function (binary, options) {
   } else {
 
     if (typeof binary === "function") {
-      // TODO: wasmMetering is currently disabled on 
-      // WebAssembly.instantiate = async function (wasm, info) {
-      //   const meteredWasm = metering.meterWASM(wasm, { meterType });
-      //   return originalInstantiate(wasm, info);
-      // };
       options.instantiateWasm = binary
     } else {
-      //binary = metering.meterWASM(binary, { meterType })
+      binary = metering.meterWASM(binary, { meterType })
       options.wasmBinary = binary
     }
 
@@ -152,9 +182,6 @@ module.exports = async function (binary, options) {
     doHandle = instance.cwrap('handle', 'string', ['string', 'string'])
   }
 
-  if (typeof binary === "function") {
-    WebAssembly.instantiate = originalInstantiate;
-  }
 
   return async (buffer, msg, env) => {
 

--- a/loader/test/emscripten2.test.js
+++ b/loader/test/emscripten2.test.js
@@ -55,7 +55,8 @@ describe('loader', async () => {
       new Response(
         Readable.toWeb(createReadStream('./test/process/process.wasm')),
         { headers: { 'Content-Type': 'application/wasm' } }
-      )
+      ),
+      { format: 'wasm32-unknown-emscripten2' }
     )
 
     const handle = await AoLoader((info, receiveInstance) => {

--- a/loader/test/index.test.js
+++ b/loader/test/index.test.js
@@ -55,7 +55,8 @@ describe('loader', async () => {
       new Response(
         Readable.toWeb(createReadStream('./test/legacy/process.wasm')),
         { headers: { 'Content-Type': 'application/wasm' } }
-      )
+      ),
+      { format: 'wasm32-unknown-emscripten' }
     )
 
     const handle = await AoLoader((info, receiveInstance) => {

--- a/servers/cu/src/config.js
+++ b/servers/cu/src/config.js
@@ -24,7 +24,7 @@ const MODE = process.env.NODE_CONFIG_ENV
 
 if (!MODE) throw new Error('NODE_CONFIG_ENV must be defined')
 
-const DEFAULT_PROCESS_WASM_MODULE_FORMATS = ['wasm32-unknown-emscripten', 'wasm32-unknown-emscripten2', 'wasm64-unknown-emscripten-draft_2024_02_15']
+const DEFAULT_PROCESS_WASM_MODULE_FORMATS = ['wasm32-unknowne-mscripten', 'wasm32-unknown-emscripten2', 'wasm32-unknown-emscripten3', 'wasm32-unknown-emscripten4', 'wasm64-unknown-emscripten-draft_2024_02_15']
 
 /**
  * The server config is an extension of the config required by the domain (business logic).

--- a/servers/cu/src/config.js
+++ b/servers/cu/src/config.js
@@ -24,7 +24,7 @@ const MODE = process.env.NODE_CONFIG_ENV
 
 if (!MODE) throw new Error('NODE_CONFIG_ENV must be defined')
 
-const DEFAULT_PROCESS_WASM_MODULE_FORMATS = ['wasm32-unknowne-mscripten', 'wasm32-unknown-emscripten2', 'wasm32-unknown-emscripten3', 'wasm32-unknown-emscripten4', 'wasm64-unknown-emscripten-draft_2024_02_15']
+const DEFAULT_PROCESS_WASM_MODULE_FORMATS = ['wasm32-unknown-emscripten', 'wasm32-unknown-emscripten2', 'wasm32-unknown-emscripten3', 'wasm32-unknown-emscripten4', 'wasm64-unknown-emscripten-draft_2024_02_15']
 
 /**
  * The server config is an extension of the config required by the domain (business logic).

--- a/servers/cu/src/effects/ao-module.js
+++ b/servers/cu/src/effects/ao-module.js
@@ -128,7 +128,7 @@ export function evaluatorWith ({ evaluateWith, loadWasmModule }) {
         return (args) =>
           Promise.resolve(!(backpressure = ++backpressure % EVAL_DEFER_BACKPRESSURE))
             .then(async (defer) => {
-              if (!wasmModule) wasmModule = await loadWasmModule({ moduleId })
+              if (!wasmModule) wasmModule = await loadWasmModule({ moduleId, moduleOptions })
               return defer
             })
             .then(async (defer) => {


### PR DESCRIPTION
closes #1034 

Just need to publish new ao-loader package to npm and update the cu's package.json to use new version.