### PR TITLE
fix(mu): add retries to iswallet to help with mistaken wallets

### DIFF
--- a/servers/mu/src/domain/clients/gateway.js
+++ b/servers/mu/src/domain/clients/gateway.js
@@ -49,7 +49,7 @@ function isWalletWith ({
         walletFetch(joinUrl({ url: ARWEAVE_URL, path: `/${id}` }), { method: 'HEAD' })
           .then(okRes),
       {
-        maxRetries: 3,
+        maxRetries: 6,
         delay: 500,
         log: logger,
         logId,


### PR DESCRIPTION
Closes (?) #905 

Adds more retries to iswallet function. Hopefully results in less wallet errors.