### PR TITLE
fix(mu): mu overwriting message types #1025

### DIFF
--- a/servers/mu/src/domain/lib/build-tx.js
+++ b/servers/mu/src/domain/lib/build-tx.js
@@ -56,18 +56,16 @@ export function buildTxWith (env) {
       )
       .map((res) => {
         const tagsIn = [
+          { name: 'Data-Protocol', value: 'ao' },
           ...ctx.cachedMsg.msg.Tags?.filter((tag) => {
             return ![
               'Data-Protocol',
-              'Type',
               'Variant',
               'From-Process',
               'From-Module',
               'Assignments'
             ].includes(tag.name)
           }) ?? [],
-          { name: 'Data-Protocol', value: 'ao' },
-          { name: 'Type', value: 'Message' },
           { name: 'Variant', value: 'ao.TN.1' },
           { name: 'From-Process', value: ctx.cachedMsg.fromProcessId },
           {

--- a/servers/mu/src/domain/lib/build-tx.js
+++ b/servers/mu/src/domain/lib/build-tx.js
@@ -57,14 +57,19 @@ export function buildTxWith (env) {
       .map((res) => {
         const tagsIn = [
           { name: 'Data-Protocol', value: 'ao' },
+          { name: 'Type', value: 'Message' },
           ...ctx.cachedMsg.msg.Tags?.filter((tag) => {
-            return ![
+            const isExcludedName = [
               'Data-Protocol',
               'Variant',
               'From-Process',
               'From-Module',
               'Assignments'
             ].includes(tag.name)
+
+            const isTypeMessage = tag.name === 'Type' && tag.value === 'Message'
+
+            return !isExcludedName && !isTypeMessage
           }) ?? [],
           { name: 'Variant', value: 'ao.TN.1' },
           { name: 'From-Process', value: ctx.cachedMsg.fromProcessId },

--- a/servers/mu/src/domain/lib/build-tx.test.js
+++ b/servers/mu/src/domain/lib/build-tx.test.js
@@ -17,6 +17,9 @@ async function buildAndSign ({ processId, tags, anchor }) {
   assert.equal(tags.find((tag) =>
     tag.name === 'From-Process'
   ).value, 'process-123')
+  assert.equal(tags.find((tag) =>
+    tag.name === 'Type'
+  ).value, 'Message')
   assert.equal(tags.filter((tag) =>
     tag.name === 'From-Process'
   ).length, 1)

--- a/servers/mu/src/domain/lib/build-tx.test.js
+++ b/servers/mu/src/domain/lib/build-tx.test.js
@@ -15,9 +15,6 @@ async function buildAndSign ({ processId, tags, anchor }) {
     tag.name === 'Data-Protocol'
   ).value, 'ao')
   assert.equal(tags.find((tag) =>
-    tag.name === 'Type'
-  ).value, 'Message')
-  assert.equal(tags.find((tag) =>
     tag.name === 'From-Process'
   ).value, 'process-123')
   assert.equal(tags.filter((tag) =>


### PR DESCRIPTION
closes #1025

fixes the error of overwriting the message types from the mu. 