### PR TITLE
fix(json): modify json.lua to support larger numbers

### DIFF
--- a/dev-cli/container/src/json.lua
+++ b/dev-cli/container/src/json.lua
@@ -74,7 +74,13 @@ local function encode_number(val)
     if val ~= val or val <= -math.huge or val >= math.huge then
         error("unexpected number value '" .. tostring(val) .. "'")
     end
-    return string.format("%.14g", val)
+    if math.floor(val) == val then
+		-- Large integers: avoid scientific notation and print as an integer
+		return string.format("%.0f", val)
+	else
+		-- Decimals: use the 'g' format to print floating point with precision, up to 14 significant digits
+		return string.format("%.14g", val)
+	end
 end
 
 local type_func_map = {


### PR DESCRIPTION
This is one approach, there are many ways to handle. But given wasm64 and lua 5.3+ support 64 bit integers more precision should be given to raw numbers when encoding.

Ref: permaweb/aos#384