### PR TITLE
fix(connect): only dedupe protocol tags on matching name AND value #1059

### DIFF
--- a/connect/src/lib/message/upload-message.js
+++ b/connect/src/lib/message/upload-message.js
@@ -37,9 +37,9 @@ function buildTagsWith () {
     return of(ctx.tags)
       .map(defaultTo([]))
       .map(removeTagsByNameMaybeValue('Data-Protocol', 'ao'))
-      .map(removeTagsByNameMaybeValue('Variant'))
-      .map(removeTagsByNameMaybeValue('Type'))
-      .map(removeTagsByNameMaybeValue('SDK'))
+      .map(removeTagsByNameMaybeValue('Variant', 'ao.TN.1'))
+      .map(removeTagsByNameMaybeValue('Type', 'Message'))
+      .map(removeTagsByNameMaybeValue('SDK', 'aoconnect'))
       .map(concat(__, [
         { name: 'Data-Protocol', value: 'ao' },
         { name: 'Variant', value: 'ao.TN.1' },

--- a/connect/src/lib/message/upload-message.test.js
+++ b/connect/src/lib/message/upload-message.test.js
@@ -13,6 +13,9 @@ describe('upload-message', () => {
         assert.ok(data)
         assert.equal(processId, 'process-asdf')
         assert.deepStrictEqual(tags, [
+          { name: 'Data-Protocol', value: 'zone' },
+          { name: 'Type', value: 'Profile' },
+          { name: 'Variant', value: 'ao.TN.Foo' },
           { name: 'foo', value: 'bar' },
           { name: 'Data-Protocol', value: 'ao' },
           { name: 'Variant', value: 'ao.TN.1' },
@@ -32,6 +35,9 @@ describe('upload-message', () => {
       id: 'process-asdf',
       signer: () => {},
       tags: [
+        { name: 'Data-Protocol', value: 'zone' },
+        { name: 'Type', value: 'Profile' },
+        { name: 'Variant', value: 'ao.TN.Foo' },
         { name: 'foo', value: 'bar' },
         { name: 'Data-Protocol', value: 'ao' },
         { name: 'Variant', value: 'ao.TN.1' }

--- a/connect/src/lib/spawn/upload-process.js
+++ b/connect/src/lib/spawn/upload-process.js
@@ -31,11 +31,11 @@ function buildTagsWith () {
       .map(prop('tags'))
       .map(defaultTo([]))
       .map(removeTagsByNameMaybeValue('Data-Protocol', 'ao'))
-      .map(removeTagsByNameMaybeValue('Variant'))
-      .map(removeTagsByNameMaybeValue('Type'))
+      .map(removeTagsByNameMaybeValue('Variant', 'ao.TN.1'))
+      .map(removeTagsByNameMaybeValue('Type', 'Message'))
       .map(removeTagsByNameMaybeValue('Module'))
       .map(removeTagsByNameMaybeValue('Scheduler'))
-      .map(removeTagsByNameMaybeValue('SDK'))
+      .map(removeTagsByNameMaybeValue('SDK', 'aoconnect'))
       .map(concat(__, [
         { name: 'Data-Protocol', value: 'ao' },
         { name: 'Variant', value: 'ao.TN.1' },

--- a/connect/src/lib/spawn/upload-process.test.js
+++ b/connect/src/lib/spawn/upload-process.test.js
@@ -12,6 +12,9 @@ describe('upload-process', () => {
       deployProcess: async ({ data, tags, signer }) => {
         assert.ok(data)
         assert.deepStrictEqual(tags, [
+          { name: 'Data-Protocol', value: 'zone' },
+          { name: 'Type', value: 'Profile' },
+          { name: 'Variant', value: 'ao.TN.Foo' },
           { name: 'foo', value: 'bar' },
           { name: 'Data-Protocol', value: 'ao' },
           { name: 'Variant', value: 'ao.TN.1' },
@@ -40,6 +43,9 @@ describe('upload-process', () => {
       module: 'module-id-123',
       scheduler: 'zVkjFCALjk4xxuCilddKS8ShZ-9HdeqeuYQOgMgWucro',
       tags: [
+        { name: 'Data-Protocol', value: 'zone' },
+        { name: 'Type', value: 'Profile' },
+        { name: 'Variant', value: 'ao.TN.Foo' },
         { name: 'foo', value: 'bar' },
         { name: 'Data-Protocol', value: 'ao' },
         { name: 'Variant', value: 'ao.TN.1' }

--- a/connect/src/lib/utils.js
+++ b/connect/src/lib/utils.js
@@ -51,15 +51,19 @@ export function parseTags (rawTags) {
  * then only remove tags whose both name and value matches.
  *
  * @param {string} name - the name of the tags to be removed
- * @param {string} [value] - the value of the tags to be removed
+ * @param {string} [valueOrPred] - the value of the tags to be removed
+ * OR a predicate function to apply to the value
  */
-export function removeTagsByNameMaybeValue (name, value) {
+export function removeTagsByNameMaybeValue (name, valueOrPred) {
   return (tags) => reject(
     allPass([
       propEq(name, 'name'),
       ifElse(
-        always(value),
-        propEq(value, 'value'),
+        always(valueOrPred),
+        (tag) => {
+          if (typeof valueOrPred === 'function') return valueOrPred(tag.value)
+          return tag.value === valueOrPred
+        },
         T
       )
     ]),


### PR DESCRIPTION
The `Module` and `Scheduler` tags are still deduped solely by tag name, on `spawn`. I don't know if there is a way around that.