### PR TITLE
fix(mu): allow duplicate tags if not default value in mu

### DIFF
--- a/servers/mu/src/domain/lib/build-success-tx.js
+++ b/servers/mu/src/domain/lib/build-success-tx.js
@@ -21,8 +21,11 @@ export function buildSuccessTxWith ({ buildAndSign, logger }) {
        * the success message, so to avoid conflicts
        */
       .map(removeTagsByNameMaybeValue('Data-Protocol', 'ao'))
-      .map(removeTagsByNameMaybeValue('Variant'))
-      .map(removeTagsByNameMaybeValue('Type'))
+      .map(removeTagsByNameMaybeValue('Variant', 'ao.TN.1'))
+      .map(removeTagsByNameMaybeValue('Type', 'Process'))
+      .map(removeTagsByNameMaybeValue('Type', 'Message'))
+      .map(removeTagsByNameMaybeValue('Process'))
+      .map(removeTagsByNameMaybeValue('Action', 'Spawned'))
       /**
        * Append tags explicitly set by the MU on the success
        * message send to the spawning process

--- a/servers/mu/src/domain/lib/build-success-tx.test.js
+++ b/servers/mu/src/domain/lib/build-success-tx.test.js
@@ -13,6 +13,7 @@ describe('buildSuccessTx', () => {
     const spawnedTags = [
       { name: 'Type', value: 'Process' },
       { name: 'Variant', value: 'ao.TN.2' },
+      { name: 'Data-Protocol', value: 'zone' },
       { name: '_Ref', value: '123' },
       { name: 'Foo', value: 'Bar' }
     ]
@@ -24,6 +25,8 @@ describe('buildSuccessTx', () => {
           stx.tags,
           [
             // from spawn.Tags
+            { name: 'Variant', value: 'ao.TN.2' },
+            { name: 'Data-Protocol', value: 'zone' },
             { name: '_Ref', value: '123' },
             { name: 'Foo', value: 'Bar' },
             // added by Mu

--- a/servers/mu/src/domain/lib/build-tx.js
+++ b/servers/mu/src/domain/lib/build-tx.js
@@ -55,17 +55,20 @@ export function buildTxWith (env) {
         }
       )
       .map((res) => {
+        const filteredTags = ctx.cachedMsg.msg.Tags
+          .filter((tag) => {
+            return !(
+              (tag.name === 'Data-Protocol' && tag.value === 'ao') ||
+              (tag.name === 'Type' && tag.value === 'Message') ||
+              (tag.name === 'Variant' && tag.value === 'ao.TN.1') ||
+              tag.name === 'From-Process' ||
+              tag.name === 'From-Module' ||
+              tag.name === 'Pushed-For' ||
+              tag.name === 'Assignments'
+            )
+          })
         const tagsIn = [
-          ...ctx.cachedMsg.msg.Tags?.filter((tag) => {
-            return ![
-              'Data-Protocol',
-              'Type',
-              'Variant',
-              'From-Process',
-              'From-Module',
-              'Assignments'
-            ].includes(tag.name)
-          }) ?? [],
+          ...filteredTags,
           { name: 'Data-Protocol', value: 'ao' },
           { name: 'Type', value: 'Message' },
           { name: 'Variant', value: 'ao.TN.1' },

--- a/servers/mu/src/domain/lib/build-tx.test.js
+++ b/servers/mu/src/domain/lib/build-tx.test.js
@@ -11,19 +11,14 @@ logger.tap = () => (args) => {
 // this is not what the buildAndSign actually returns
 // using tags here as data for testing
 async function buildAndSign ({ processId, tags, anchor }) {
-  assert.equal(tags.find((tag) =>
-    tag.name === 'Data-Protocol'
-  ).value, 'ao')
-  assert.equal(tags.find((tag) =>
-    tag.name === 'Type'
-  ).value, 'Message')
-  assert.equal(tags.find((tag) =>
-    tag.name === 'From-Process'
-  ).value, 'process-123')
-  assert.equal(tags.filter((tag) =>
-    tag.name === 'From-Process'
-  ).length, 1)
-
+  assert.deepStrictEqual(tags, [
+    { name: 'foo', value: 'bar' },
+    { name: 'Data-Protocol', value: 'ao' },
+    { name: 'Type', value: 'Message' },
+    { name: 'Variant', value: 'ao.TN.1' },
+    { name: 'From-Process', value: 'process-123' },
+    { name: 'From-Module', value: 'mod-1' }
+  ])
   return {
     id: 'id-1',
     data: Buffer.alloc(0),
@@ -69,7 +64,9 @@ describe('buildTx', () => {
         msg: {
           Target: 'id-1',
           Tags: [
-            { name: 'Assignments', value: ['p1', 'p2'] }
+            { name: 'Type', value: 'Message' },
+            { name: 'Assignments', value: ['p1', 'p2'] },
+            { name: 'foo', value: 'bar' }
           ],
           Anchor: 'anchor-1',
           Data: 'data-1'
@@ -98,6 +95,7 @@ describe('buildTx', () => {
         msg: {
           Target: 'id-1',
           Tags: [
+            { name: 'foo', value: 'bar' },
             { name: 'Assignments', value: ['p1', 'p2'] },
             { name: 'From-Process', value: 'Process1' },
             { name: 'From-Process', value: 'Process2' }

--- a/servers/mu/src/domain/lib/spawn-process.js
+++ b/servers/mu/src/domain/lib/spawn-process.js
@@ -40,12 +40,16 @@ export function spawnProcessWith (env) {
   return (ctx) => {
     if (!checkStage('spawn-process')(ctx)) return Resolved(ctx)
     const { Tags, Data } = ctx.cachedSpawn.spawn
-
-    const tagsIn = Tags.filter(tag => ![
-      'Data-Protocol',
-      'Type',
-      'Variant'
-    ].includes(tag.name))
+    const tagsIn = Tags
+      .filter((tag) => {
+        return !(
+          (tag.name === 'Data-Protocol' && tag.value === 'ao') ||
+          (tag.name === 'Type' && tag.value === 'Process') ||
+          (tag.name === 'Variant' && tag.value === 'ao.TN.1') ||
+          tag.name === 'From-Process' ||
+          tag.name === 'Pushed-For'
+        )
+      })
 
     tagsIn.push({ name: 'Data-Protocol', value: 'ao' })
     tagsIn.push({ name: 'Type', value: 'Process' })

--- a/servers/mu/src/domain/lib/spawn-process.test.js
+++ b/servers/mu/src/domain/lib/spawn-process.test.js
@@ -1,46 +1,104 @@
-import { describe } from 'node:test'
-// import * as assert from 'node:assert'
+import { describe, test } from 'node:test'
+import * as assert from 'node:assert'
 
-// import { createLogger } from '../../logger.js'
-// import { spawnProcessWith } from './spawn-process.js'
+import { spawnProcessWith } from './spawn-process.js'
 
-// const logger = createLogger('ao-mu:spawnProcess')
+const logger = () => undefined
+logger.tap = () => (args) => {
+  return args
+}
 
 describe('spawnProcess', () => {
-  // test('spawn process', async () => {
-  //   const spawn1 = {
-  //     tags: [
-  //       { name: 'Data-Protocol', value: 'ao' },
-  //       { name: 'Contract-Src', value: 'src-1' },
-  //       { name: 'ao-type', value: 'process' }
-  //     ]
-  //   }
-  //   const cachedSpawn1 = {
-  //     id: Math.floor(Math.random() * 1e18).toString(),
-  //     spawn: spawn1,
-  //     cachedAt: new Date(),
-  //     processId: 'pid-1'
-  //   }
-  //   const spawnProcess = spawnProcessWith({
-  //     writeProcessTx: async (spawnData) => {
-  //       // the program extracts this from the tag and puts it in src
-  //       assert.equal(spawnData.src, 'src-1')
-  //       /**
-  //        * all tags should be removed in this case because they
-  //        * would get duplicated by the sdk spawnProcess call
-  //        * the program should only pass through tags that are
-  //        * not built in part of ao
-  //        */
-  //       assert.equal(spawnData.tags.length, 0)
-  //       return 'pid-1'
-  //     },
-  //     logger
-  //   })
+  test('spawn process', async () => {
+    const spawn = {
+      Tags: [
+        { name: 'Data-Protocol', value: 'ao' },
+        { name: 'Data-Protocol', value: 'zone' },
+        { name: 'Type', value: 'Process' },
+        { name: 'Module', value: 'mod-1' },
+        { name: 'Scheduler', value: 'scheduler-123' },
+        { name: 'foo', value: 'bar' }
+      ],
+      Data: 'data-123'
+    }
+    const cachedSpawn = {
+      id: '123',
+      spawn,
+      processId: 'pid-1'
+    }
+    const spawnProcess = spawnProcessWith({
+      writeDataItem: async ({ data, suUrl, logId }) => {
+        assert.equal(data, 'new-data-123')
+        assert.equal(suUrl, 'url-123')
+        assert.equal(logId, 'log-123')
 
-  //   const result = await spawnProcess({
-  //     cachedSpawn: cachedSpawn1
-  //   }).toPromise()
+        return {
+          id: 'data-item-id-123',
+          timestamp: 1234567
+        }
+      },
+      fetchSchedulerProcess: async (processId, url, logId) => {
+        assert.equal(processId, 'pid-1')
+        assert.equal(url, 'url-123')
+        assert.equal(logId, 'log-123')
+        return {
+          process_id: 'pid-1',
+          block: 'block-123',
+          owner: {
+            address: 'owner-address-123',
+            key: 'owner-key-123'
+          },
+          tags: [
+            { name: 'Module', value: 'scheduler-module-123' }
+          ],
+          timestamp: 1234567,
+          signature: 'signature-123'
+        }
+      },
+      locateScheduler: async (scheduler) => {
+        assert.equal(scheduler, 'scheduler-123')
+        return {
+          url: 'url-123'
+        }
+      },
+      locateNoRedirect: async (processId) => {
+        assert.equal(processId, 'pid-1')
+        return { url: 'url-123', address: 'address-123' }
+      },
+      buildAndSign: async (stx) => {
+        assert.equal(stx.data, 'data-123')
+        assert.deepStrictEqual(
+          stx.tags,
+          [
+            // passed in
+            { name: 'Data-Protocol', value: 'zone' },
+            { name: 'Module', value: 'mod-1' },
+            { name: 'Scheduler', value: 'scheduler-123' },
+            { name: 'foo', value: 'bar' },
+            // added by Mu
+            { name: 'Data-Protocol', value: 'ao' },
+            { name: 'Type', value: 'Process' },
+            { name: 'Variant', value: 'ao.TN.1' },
+            { name: 'From-Process', value: 'pid-1' }
+          ]
+        )
+        return {
+          id: 'new-process-id',
+          data: 'new-data-123',
+          processId: 'pid-1'
+        }
+      },
+      logger
+    })
 
-  //   assert.equal(result.processTx, 'pid-1')
-  // })
+    const result = await spawnProcess({
+      cachedSpawn,
+      logId: 'log-123'
+    }).toPromise()
+
+    assert.deepStrictEqual(result.cachedSpawn, cachedSpawn)
+    assert.equal(result.logId, 'log-123')
+    assert.equal(result.processTx, 'new-process-id')
+    assert.equal(result.messageId, 'new-process-id')
+  })
 })


### PR DESCRIPTION
Only filter out tags that MU is explicitly overwriting to avoid duplicating. 