### PR TITLE
fix: bump rustc in su Dockerfiles to 1.78

### DIFF
--- a/servers/su/Dockerfile
+++ b/servers/su/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the dynamic binary
-FROM rust:1.75.0 as builder
+FROM rust:1.78.0 as builder
 
 # Set the working directory in the container
 WORKDIR /usr/src/su

--- a/servers/su/Dockerfile.arm64
+++ b/servers/su/Dockerfile.arm64
@@ -1,14 +1,14 @@
 ### NOTE: THIS WON'T WORK ON AN X86 DEVICE
 
 # Stage 1: Planner
-FROM --platform=linux/arm64  rust:1.75.0 AS planner
+FROM --platform=linux/arm64  rust:1.78.0 AS planner
 WORKDIR /app
 RUN cargo install cargo-chef
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 # Stage 2: Cache the build of the dependencies
-FROM --platform=linux/arm64 rust:1.75.0 AS cacher
+FROM --platform=linux/arm64 rust:1.78.0 AS cacher
 WORKDIR /app
 RUN cargo install cargo-chef
 RUN apt-get update && apt-get install -y \
@@ -23,7 +23,7 @@ RUN ls /lib/
 RUN cargo chef cook --release --recipe-path recipe.json
 
 # Stage 3: Build binary with pre-built and cached dependencies
-FROM --platform=linux/arm64 rust:1.75.0 AS builder
+FROM --platform=linux/arm64 rust:1.78.0 AS builder
 COPY . /app
 WORKDIR /app
 COPY --from=cacher /app/target target
@@ -33,7 +33,7 @@ COPY --from=cacher /lib/aarch64-linux-gnu/*  /lib/aarch64-linux-gnu/
 RUN cargo build --release
 
 # Stage 4: Runner 
-FROM --platform=linux/arm64 gcr.io/distroless/cc-debian12 
+FROM --platform=linux/arm64 ubuntu:22.04 
 RUN apt-get update && apt install ca-certificates openssl -y
 COPY --from=builder /app/target/release/su /
 COPY --from=cacher /lib/aarch64-linux-gnu/*  /lib/aarch64-linux-gnu/

--- a/servers/su/Dockerfile.x86
+++ b/servers/su/Dockerfile.x86
@@ -1,14 +1,14 @@
 ### NOTE: THIS WON'T WORK ON AN ARM64 DEVICE
 
 # Stage 1: Planner
-FROM --platform=linux/amd64 rust:1.75.0 AS planner
+FROM --platform=linux/amd64 rust:1.78.0 AS planner
 WORKDIR /app
 RUN cargo install cargo-chef
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 # Stage 2: Cache the build of the dependencies
-FROM --platform=linux/amd64 rust:1.75.0 AS cacher
+FROM --platform=linux/amd64 rust:1.78.0 AS cacher
 WORKDIR /app
 RUN cargo install cargo-chef
 RUN apt-get update && apt-get install -y \
@@ -24,7 +24,7 @@ RUN ls /lib/
 RUN cargo chef cook --release --recipe-path recipe.json
 
 # Stage 3: Build binary with pre-built and cached dependencies
-FROM --platform=linux/amd64 rust:1.75.0 AS builder
+FROM --platform=linux/amd64 rust:1.78.0 AS builder
 COPY . /app
 WORKDIR /app
 COPY --from=cacher /app/target target


### PR DESCRIPTION
`cargo-chef` dependency. Local build of the image works (arm64). Should work for x86 with github workflow as a consequence.