### PR TITLE
fix(aostdio): return fread bytes read from weavedrive_read

### DIFF
--- a/dev-cli/container/src/aolibc/aostdio.c
+++ b/dev-cli/container/src/aolibc/aostdio.c
@@ -48,9 +48,11 @@ FILE* fopen(const char* filename, const char* mode) {
 }
 
 size_t fread(void* ptr, size_t size, size_t nmemb, FILE* stream) {
+    AO_LOG( "AO: fread called\n");
     int fd = fileno(stream);
-    weavedrive_read(fd, ptr, size * nmemb);
-    return nmemb;
+    int bytes_read = weavedrive_read(fd, ptr, size * nmemb);
+    AO_LOG( "AO: weavedrive_read returned %d bytes\n", bytes_read);
+    return bytes_read;
 }
 
 int fclose(FILE* stream) {


### PR DESCRIPTION
From https://en.cppreference.com/w/c/io/fread
```
Return value

Number of objects read successfully, which may be less than count if an error or end-of-file condition occurs.
```