### PR TITLE
[docfixed]: dev-cli, ao init --lang options are 'lua' and 'c'

### DIFF
--- a/dev-cli/src/commands/init.js
+++ b/dev-cli/src/commands/init.js
@@ -19,7 +19,7 @@ export async function init ({ lang = 'lua' }, name) {
 
 export const command = new Command()
   .description('Create an ao Process Source Project')
-  .usage('-l cpp <my-project-name>')
+  .usage('-l c <my-project-name>')
   .option(
     '-l, --lang <language:string>',
     'The starter to use. Defaults to Lua. Options are "lua" and "c"'

--- a/dev-cli/src/commands/init.js
+++ b/dev-cli/src/commands/init.js
@@ -22,7 +22,7 @@ export const command = new Command()
   .usage('-l cpp <my-project-name>')
   .option(
     '-l, --lang <language:string>',
-    'The starter to use. Defaults to Lua. Options are "lua" and "cpp"'
+    'The starter to use. Defaults to Lua. Options are "lua" and "c"'
   )
   .arguments('<name:string>')
   .action(init)


### PR DESCRIPTION
The current `ao init --help <project_name>` output shows the following:

```
~/ai_repub » ao init --help

Usage:   ao init -l cpp <my-project-name>
Version: 0.1.7

Description:

  Create an ao Process Source Project

Options:

  -h, --help              - Show this help.
  -l, --lang  <language>  - The starter to use. Defaults to Lua. Options are "lua" and "cpp"
```

However, the actual supported options are "lua" and "c", which matches the structure inside the folder.
*Using "cpp" will fallback to `lua` (as default).*

```
 ls ~/.ao/starters                                                                                                                          1 ↵
c  lua
```