### PR TITLE
fix(connect): support spawn data ArrayBuffer type

### DIFF
--- a/connect/src/lib/spawn/index.js
+++ b/connect/src/lib/spawn/index.js
@@ -15,7 +15,7 @@ import { uploadProcessWith } from './upload-process.js'
  * @property {string} scheduler
  * @property {Types['signer']} signer
  * @property {{ name: string, value: string }[]} [tags]
- * @property {string} [data]
+ * @property {string | ArrayBuffer} [data]
  *
  * @callback SpawnProcess
  * @param {SpawnProcessArgs} args


### PR DESCRIPTION
Currently aoconnect's `spawn` function's `data` option is incorrectly limited to a string type, whereas the internal implementaiton [supports ArrayBuffer types](https://github.com/permaweb/ao/blob/main/connect/src/lib/spawn/upload-process.js#L27), which is relevant when using non-text data. This small PR fixes this type.
