### PR TITLE
Fix[dev_cli] fixed inject_c_files in ao-build-module

### DIFF
--- a/dev-cli/container/src/ao-build-module
+++ b/dev-cli/container/src/ao-build-module
@@ -70,7 +70,7 @@ def main():
     
     # Inject c files into c_program if language is c
     if(language == 'c'):
-        c_program = inject_c_files(definition, c_program, c_source_files)
+        c_program = inject_c_files(definition, c_program, c_source_files, link_libraries)
     
     # Inject rust files into c_program if language is rust
     if(language == 'rust'):


### PR DESCRIPTION
The function definition is here:

https://github.com/permaweb/ao/blob/main/dev-cli/container/src/ao_module_lib/languages/c.py

```py
def inject_c_files(definition: Definition, c_program: str, c_source_files: list, link_libraries: list):
```

And the original code may cause error like:

```sh
ao build
Traceback (most recent call last):
  File "/usr/local/bin/ao-build-module", line 164, in <module>
    main()
  File "/usr/local/bin/ao-build-module", line 73, in main
    c_program = inject_c_files(definition, c_program, c_source_files)
TypeError: inject_c_files() missing 1 required positional argument: 'link_libraries'
```

