### PR TITLE
Fix[dev-cli]: root_dir: use absolute path instead of relative path

### DIFF
--- a/dev-cli/tools/build.sh
+++ b/dev-cli/tools/build.sh
@@ -3,7 +3,7 @@
 # Build the ao cli into a set of platform binaries
 
 # change directory to root of dev-cli to ensure this script works no matter where it is ran
-root_dir="$(dirname "$0")/.."
+root_dir="$(realpath "$(dirname "$0")/..")"
 cd $root_dir
 
 OUTPUT_DIR="${root_dir}/dist"


### PR DESCRIPTION
The output of $(dirname "$0")/.." is a relative path, which may cause an error:

```
zip I/O error: No such file or directory
```

