### PR TITLE
Fixed[dev-cli] fix deno std issue

### DIFF
--- a/dev-cli/src/deps.js
+++ b/dev-cli/src/deps.js
@@ -1,4 +1,4 @@
-export { Command } from 'https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts'
+export { Command } from 'https://deno.land/x/cliffy@v1.0.0-rc.4/command/mod.ts'
 export { basename, resolve } from 'https://deno.land/std@0.224.0/path/mod.ts'
 export { copy } from 'https://deno.land/std@0.224.0/fs/copy.ts'
 export { parse } from 'jsr:@std/yaml'


### PR DESCRIPTION
When executing commands, errors may occur because deno-cliffy introduces an older version of std. The solution is to upgrade deno-cliffy to version r4.

```shell
deno --version
deno 2.1.6 (stable, release, x86_64-unknown-linux-gnu)
v8 13.0.245.12-rusty
typescript 5.6.2
```

```shell
deno task build-binaries

Task build-binaries ./tools/build.sh
updating: c/ (stored 0%)
updating: c/process.c (deflated 54%)
updating: c/libcjson/ (stored 0%)
updating: c/libcjson/cJSON.h (deflated 69%)
updating: c/libcjson/libcjson.a (deflated 59%)
updating: c/libcjson/cJSON.c (deflated 81%)
updating: c/ao.h (deflated 71%)
updating: c/ao.c (deflated 78%)
updating: c/helpers.c (deflated 77%)
updating: c/helpers.h (deflated 63%)
updating: lua/ (stored 0%)
updating: lua/process.lua (deflated 30%)
updating: lua/ao.lua (deflated 74%)
Compile file:///home/ryan/ao/dev-cli/src/mod.js to /home/ryan/ao/dev-cli/./tools/../dist/ao
error: Writing deno compile executable to temporary file '/home/ryan/ao/dev-cli/./tools/../dist/ao.tmp-a1cba5297137a32a'

Caused by:
    Import assertions are deprecated. Use `with` keyword, instead of 'assert' keyword.

    import data from "./_data.json" assert { type: "json" };

      at https://deno.land/std@0.196.0/console/unicode_width.ts:4:1

....
```
**Note: It is recommended to update deno.lock at the same time. Maintainers can choose to either close this PR and update it themselves or merge this PR and update deno.lock.**

related PR: https://github.com/c4spar/deno-cliffy/pull/691

