### PR TITLE
feat[dev-cli]: support custom image

### DIFF
--- a/dev-cli/src/commands/build.js
+++ b/dev-cli/src/commands/build.js
@@ -3,8 +3,10 @@
 import { Command } from '../deps.js'
 import { VERSION } from '../versions.js'
 
-export async function build () {
+export async function build(customImage) {
   const pwd = Deno.cwd()
+  const image = customImage || `p3rmaw3b/ao:${VERSION.IMAGE}`
+
   const p = Deno.run({
     cmd: [
       'docker',
@@ -13,7 +15,7 @@ export async function build () {
       'linux/amd64',
       '-v',
       `${pwd}:/src`,
-      `p3rmaw3b/ao:${VERSION.IMAGE}`,
+      image,
       'ao-build-module'
     ]
   })
@@ -22,4 +24,7 @@ export async function build () {
 
 export const command = new Command()
   .description('Build the Lua Project into WASM')
-  .action(build)
+  .option('-i, --image <image:string>', 'Specify a custom Docker image to use')
+  .action(async (options) => {
+    await build(options.image)
+  })


### PR DESCRIPTION
Support the ao build command to invoke local/custom Docker images, facilitating local development and testing.

```bash
ao build --help

Usage:   ao build
Version: 0.1.7

Description:

  Build the Lua Project into WASM

Options:

  -h, --help            - Show this help.
  -i, --image  <image>  - Specify a custom Docker image to use
```