### PR TITLE
feat(loader): revert free call in wasm64

### DIFF
--- a/loader/src/formats/wasm64-emscripten.cjs
+++ b/loader/src/formats/wasm64-emscripten.cjs
@@ -4929,14 +4929,10 @@ var Module = (() => {
           assert(!(previousAsync && !Asyncify.currData), "We cannot stop an async operation in flight");
           assert(asyncMode, "The call to " + ident + " is running asynchronously. If this was intended, add the async option to the ccall/cwrap call.");
           return Asyncify.whenDone().then(onDone).then(res => {
-            // CHG: free ptr of returned result in HEAP Memory
-            _free(ret)
             return res;
           });
         }
         let res = onDone(ret);
-        // CHG: free ptr of returned result in HEAP Memory
-        _free(ret);
         if (asyncMode) return Promise.resolve(res);
         return res;
       };


### PR DESCRIPTION
This PR reverts a previous pr that adds a _free function to the wasm64 glue code in ao-loader. The result of that implementation did not work.