### PR TITLE
Process must exit when receiving SIGTERM

### DIFF
--- a/servers/mu/src/app.js
+++ b/servers/mu/src/app.js
@@ -18,8 +18,11 @@ export const server = pipe(
     })
 
     process.on('SIGTERM', () => {
-      logger({ log: 'Recevied SIGTERM. Gracefully shutting down server...' })
-      server.close(() => logger({ log: 'Server Shut Down' }))
+      logger({ log: 'Received SIGTERM. Gracefully shutting down server...' })
+      server.close(() => {
+        logger({ log: 'Server Shut Down' })
+        process.exit()
+      })
     })
 
     domain.apis.initCronProcs().then(() => {

--- a/servers/ur/src/app.js
+++ b/servers/ur/src/app.js
@@ -25,8 +25,11 @@ pipe(
     })
 
     process.on('SIGTERM', () => {
-      logger('Recevied SIGTERM. Gracefully shutting down server...')
-      server.close(() => logger('Server Shut Down'))
+      logger('Received SIGTERM. Gracefully shutting down server...')
+      server.close(() => {
+        logger('Server Shut Down')
+        process.exit()
+      })
     })
 
     return server


### PR DESCRIPTION
When a process is stopped using a signal (`SIGTERM` with `systemd` for example), it should be stopped using `process.exit()` function. If not, the node process will still be running and a `SIGKILL` will be required to stop it.