### PR TITLE
fix(su): fix su returing process on first from

### DIFF
--- a/servers/su/src/domain/clients/store.rs
+++ b/servers/su/src/domain/clients/store.rs
@@ -916,12 +916,7 @@ impl DataStore for StoreClient {
         // Determine if the 'from' timestamp matches the process timestamp and if assignment is present
         let include_process = process_in.assignment.is_some()
             && match from {
-                Some(from_timestamp_str) => {
-                    let from_timestamp = from_timestamp_str
-                        .parse::<i64>()
-                        .map_err(StoreErrorType::from)?;
-                    from_timestamp == process_in.process.timestamp
-                }
+                Some(_) => false,
                 None => true, // No 'from' timestamp means it's the first page
             };
 


### PR DESCRIPTION
This bug has always existed in the SU but hash chain verification surfaced it. The process and its assignment were being returned when the from cursor was the process timestamp. When hash chain verification was enabled, this caused spawns to fail.

This does mean that if this is put in testnet, Processes that got evaluated with the process message twice before will now only get it once if cold started.