### PR TITLE
feat(cu): create config allowing to disable checkpoins without hash chain

### DIFF
--- a/servers/cu/README.md
+++ b/servers/cu/README.md
@@ -120,6 +120,8 @@ There are a few environment variables that you can set. Besides
   `Checkpoint` creation to the file system. (You must explicitly enable
   `Checkpoint` creation by setting - `DISABLE_PROCESS_FILE_CHECKPOINT_CREATION`
   to `'false'`)
+- `DISABLE_NON_HASH_CHAIN_CHECKPOINTS`: Whether to disable non-hash chain
+  checkpoints. Set to `true` to disable non-hash chain checkpoints.
 - `EAGER_CHECKPOINT_ACCUMULATED_GAS_THRESHOLD`: If a process uses this amount of
   gas, then it will immediately create a Checkpoint at the end of the evaluation
   stream.

--- a/servers/cu/src/bootstrap.js
+++ b/servers/cu/src/bootstrap.js
@@ -209,6 +209,7 @@ export const createApis = async (ctx) => {
   })
 
   ctx.logger('Process Arweave Checkpoint creation is set to "%s"', !ctx.DISABLE_PROCESS_CHECKPOINT_CREATION)
+  ctx.logger('Disabling non-hash chain checkpoints is set to "%s"', ctx.DISABLE_NON_HASH_CHAIN_CHECKPOINTS)
   ctx.logger('Process File Checkpoint creation is set to "%s"', !ctx.DISABLE_PROCESS_FILE_CHECKPOINT_CREATION)
   ctx.logger('Ignoring Arweave Checkpoints for processes [ %s ]', ctx.PROCESS_IGNORE_ARWEAVE_CHECKPOINTS.join(', '))
   ctx.logger('Ignoring Arweave Checkpoints [ %s ]', ctx.IGNORE_ARWEAVE_CHECKPOINTS.join(', '))
@@ -333,6 +334,7 @@ export const createApis = async (ctx) => {
       PROCESS_IGNORE_ARWEAVE_CHECKPOINTS: ctx.PROCESS_IGNORE_ARWEAVE_CHECKPOINTS,
       IGNORE_ARWEAVE_CHECKPOINTS: ctx.IGNORE_ARWEAVE_CHECKPOINTS,
       PROCESS_CHECKPOINT_TRUSTED_OWNERS: ctx.PROCESS_CHECKPOINT_TRUSTED_OWNERS,
+      DISABLE_NON_HASH_CHAIN_CHECKPOINTS: ctx.DISABLE_NON_HASH_CHAIN_CHECKPOINTS,
       logger
     }),
     saveLatestProcessMemory: AoProcessClient.saveLatestProcessMemoryWith({

--- a/servers/cu/src/config.js
+++ b/servers/cu/src/config.js
@@ -144,6 +144,7 @@ const CONFIG_ENVS = {
     DISABLE_PROCESS_CHECKPOINT_CREATION: process.env.DISABLE_PROCESS_CHECKPOINT_CREATION !== 'false',
     DISABLE_PROCESS_FILE_CHECKPOINT_CREATION: process.env.DISABLE_PROCESS_FILE_CHECKPOINT_CREATION !== 'false',
     DISABLE_PROCESS_EVALUATION_CACHE: process.env.DISABLE_PROCESS_EVALUATION_CACHE,
+    DISABLE_NON_HASH_CHAIN_CHECKPOINTS: process.env.DISABLE_NON_HASH_CHAIN_CHECKPOINTS === 'true',
     /**
      *  EAGER_CHECKPOINT_ACCUMULATED_GAS_THRESHOLD: Amount of gas for 2 hours of continuous compute (300_000_000_000_000)
      *  This was calculated by creating a process built to do continuous compute. After 2 hours, this process used
@@ -196,6 +197,7 @@ const CONFIG_ENVS = {
     DISABLE_PROCESS_CHECKPOINT_CREATION: process.env.DISABLE_PROCESS_CHECKPOINT_CREATION !== 'false',
     DISABLE_PROCESS_FILE_CHECKPOINT_CREATION: process.env.DISABLE_PROCESS_FILE_CHECKPOINT_CREATION !== 'false',
     DISABLE_PROCESS_EVALUATION_CACHE: process.env.DISABLE_PROCESS_EVALUATION_CACHE,
+    DISABLE_NON_HASH_CHAIN_CHECKPOINTS: process.env.DISABLE_NON_HASH_CHAIN_CHECKPOINTS === 'true',
     /**
      *  EAGER_CHECKPOINT_ACCUMULATED_GAS_THRESHOLD: Amount of gas for 2 hours of continuous compute (300_000_000_000_000)
      *  This was calculated by creating a process built to do continuous compute by adding and clearing a table.

--- a/servers/cu/src/domain/model.js
+++ b/servers/cu/src/domain/model.js
@@ -109,6 +109,10 @@ export const domainConfigSchema = z.object({
    */
   DISABLE_PROCESS_EVALUATION_CACHE: z.preprocess((val) => !!val, z.boolean()),
   /**
+   * Whether to disable non-hash chain checkpoints
+   */
+  DISABLE_NON_HASH_CHAIN_CHECKPOINTS: z.preprocess((val) => !!val, z.boolean()),
+  /**
    * If a process uses this amount of
    * gas, then it will immediately create a Checkpoint at the end of the
    * evaluation stream.


### PR DESCRIPTION
Closes #1165 

Create config var, `DISABLE_NON_HASH_CHAIN_CHECKPOINTS`, which, when set to true, skips checkpoints missing the `Hash-Chain` or `Assignment` tags.