### PR TITLE
feat: create standalone signer / dispatch APIs (signMessage / sendSignedMessage)

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -19,6 +19,8 @@ This module will run in a browser or server environment.
     - [`result`](#result)
     - [`results`](#results)
     - [`message`](#message)
+    - [`signMessage`](#signMessage)
+    - [`sendSignedMessage`](#sendSignedMessage)
     - [`spawn`](#spawn)
     - [`connect`](#connect)
     - [`monitor`](#monitor)
@@ -105,7 +107,7 @@ Parameters
 
 #### `message`
 
-send a message to an `ao` Message Unit `mu` targeting an ao `process`.
+Send a message to an `ao` Message Unit `mu` targeting an ao `process`.
 
 ```js
 import { createSigner, message } from "@permaweb/aoconnect";
@@ -120,6 +122,34 @@ const messageId = await message({
 ```
 
 > You can pass a 32 byte `anchor` to `message` which will be set on the DataItem
+
+#### `signMessage`
+ 
+ Prepare and sign an `ao` message which can later be dispatched using `sendSignedMessage`
+ 
+ ```js
+ import { createSigner, signMessage } from "@permaweb/aoconnect";
+ 
+ const signedMessage = await signMessage({
+   process,
+   signer: createSigner(wallet),
+   anchor,
+   tags,
+   data,
+ });
+ ```
+ 
+ > You can pass a 32 byte `anchor` to `message` which will be set on the DataItem
+ 
+ #### `sendSignedMessage`
+ 
+ Dispatch a previously signed message
+ 
+ ```js
+ import { createSigner, sendSignedMessage } from "@permaweb/aoconnect";
+ 
+ const signedMessage = await sendSignedMessage(signedMessage);
+ ```
 
 #### `spawn`
 

--- a/connect/src/client/ao-mu.js
+++ b/connect/src/client/ao-mu.js
@@ -1,6 +1,56 @@
 import { Rejected, fromPromise, of } from 'hyper-async'
 
 import { toDataItemSigner } from './signer.js'
+import { verify } from '../lib/data-item.js'
+
+function signDataItemChain(args, logger) {
+  return of(args)
+    .chain(fromPromise(({ processId, data, tags, anchor, signer }) =>
+      toDataItemSigner(signer)({ data, tags, target: processId, anchor })
+    ))
+    .map(logger.tap('Successfully built and signed data item'));
+}
+
+function sendDataItemChain(signedDataItem, { fetch, MU_URL, logger, verifyBeforeSend = false }) {
+  let chain = of(signedDataItem);
+  if (verifyBeforeSend) {
+    chain = chain.chain(fromPromise(async (item) => {
+      const verified = await verify(item.raw);
+      if (!verified) throw new Error('Signed data item verification failed.');
+      return item;
+    }));
+  }
+  return chain
+    .chain(fromPromise(async (item) =>
+      fetch(MU_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          Accept: 'application/json'
+        },
+        redirect: 'follow',
+        body: item.raw
+      })
+    ))
+    .bichain(
+      (err) => {
+        if (err.name === 'RedirectRequested') {
+          return Rejected(err);
+        } else {
+          return Rejected(new Error(`Error while communicating with MU: ${JSON.stringify(err)}`));
+        }
+      },
+      fromPromise(async (res) => {
+        if (res.ok) return res.json();
+        throw new Error(`${res.status}: ${await res.text()}`);
+      })
+    )
+    .bimap(
+      logger.tap('Error encountered when writing message via MU'),
+      logger.tap('Successfully wrote message via MU')
+    )
+    .map((res) => ({ res, messageId: signedDataItem.id }));
+}
 
 /**
  * @typedef Env3
@@ -20,64 +70,27 @@ import { toDataItemSigner } from './signer.js'
  * @param {Env3} env
  * @returns {WriteMessage2}
  */
-export function deployMessageWith ({ fetch, MU_URL, logger: _logger }) {
-  const logger = _logger.child('deployMessage')
-
+export function deployMessageWith({ fetch, MU_URL, logger: _logger }) {
+  const logger = _logger.child('deployMessage');
   return (args) => {
-    return (
-      of(args)
-        /**
-         * Sign with the provided signer
-         */
-        .chain(
-          fromPromise(({ processId, data, tags, anchor, signer }) =>
-            toDataItemSigner(signer)({ data, tags, target: processId, anchor })
-          )
-        )
-        .map(logger.tap('Successfully built and signed data item'))
-        .chain((signedDataItem) =>
-          of(signedDataItem)
-            .chain(
-              fromPromise(async (signedDataItem) =>
-                fetch(MU_URL, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/octet-stream',
-                    Accept: 'application/json'
-                  },
-                  redirect: 'follow',
-                  body: signedDataItem.raw
-                })
-              )
-            )
-            .bichain(
-              (err) => {
-                if (err.name === 'RedirectRequested') {
-                  return Rejected(err)
-                } else {
-                  return Rejected(
-                    new Error(
-                      `Error while communicating with MU: ${JSON.stringify(
-                        err
-                      )}`
-                    )
-                  )
-                }
-              },
-              fromPromise(async (res) => {
-                if (res.ok) return res.json()
-                throw new Error(`${res.status}: ${await res.text()}`)
-              })
-            )
-            .bimap(
-              logger.tap('Error encountered when writing message via MU'),
-              logger.tap('Successfully wrote message via MU')
-            )
-            .map((res) => ({ res, messageId: signedDataItem.id }))
-        )
-        .toPromise()
-    )
-  }
+    return signDataItemChain(args, logger)
+      .chain((signedDataItem) => sendDataItemChain(signedDataItem, { fetch, MU_URL, logger }))
+      .toPromise();
+  };
+}
+
+export function signMessageWith({ logger: _logger }) {
+  const logger = _logger.child('signMessage');
+  return (args) => {
+    return signDataItemChain(args, logger).toPromise();
+  };
+}
+
+export function sendSignedMessageWith({ fetch, MU_URL, logger: _logger }) {
+  const logger = _logger.child('sendSignedMessage');
+  return (signedDataItem) => {
+    return sendDataItemChain(signedDataItem, { fetch, MU_URL, logger, verifyBeforeSend: true }).toPromise();
+  };
 }
 
 /**
@@ -94,7 +107,7 @@ export function deployMessageWith ({ fetch, MU_URL, logger: _logger }) {
  * @param {Env3} env
  * @returns {RegisterProcess}
  */
-export function deployProcessWith ({ fetch, MU_URL, logger: _logger }) {
+export function deployProcessWith({ fetch, MU_URL, logger: _logger }) {
   const logger = _logger.child('deployProcess')
 
   return (args) => {
@@ -158,7 +171,7 @@ export function deployProcessWith ({ fetch, MU_URL, logger: _logger }) {
  * @param {Env4} env
  * @returns {MonitorResult}
  */
-export function deployMonitorWith ({ fetch, MU_URL, logger: _logger }) {
+export function deployMonitorWith({ fetch, MU_URL, logger: _logger }) {
   const logger = _logger.child('deployMonitor')
 
   return (args) =>
@@ -222,7 +235,7 @@ export function deployMonitorWith ({ fetch, MU_URL, logger: _logger }) {
  * @param {Env5} env
  * @returns {MonitorResult}
  */
-export function deployUnmonitorWith ({ fetch, MU_URL, logger: _logger }) {
+export function deployUnmonitorWith({ fetch, MU_URL, logger: _logger }) {
   const logger = _logger.child('deployUnmonitor')
 
   return (args) =>
@@ -296,7 +309,7 @@ export function deployUnmonitorWith ({ fetch, MU_URL, logger: _logger }) {
  * @param {Env6} env
  * @returns {WriteAssign}
  */
-export function deployAssignWith ({ fetch, MU_URL, logger: _logger }) {
+export function deployAssignWith({ fetch, MU_URL, logger: _logger }) {
   const logger = _logger.child('deployAssign')
 
   return (args) => {
@@ -304,8 +317,7 @@ export function deployAssignWith ({ fetch, MU_URL, logger: _logger }) {
       .chain(
         fromPromise(async ({ process, message, baseLayer, exclude }) =>
           fetch(
-            `${MU_URL}?process-id=${process}&assign=${message}${
-              baseLayer ? '&base-layer' : ''
+            `${MU_URL}?process-id=${process}&assign=${message}${baseLayer ? '&base-layer' : ''
             }${exclude ? '&exclude=' + exclude.join(',') : ''}`,
             {
               method: 'POST',

--- a/connect/src/dal.js
+++ b/connect/src/dal.js
@@ -61,6 +61,32 @@ export const deployMessageSchema = z.function()
     }).passthrough()
   ))
 
+export const prepareMessageSchema = z.function()
+  .args(z.object({
+    processId: z.string(),
+    data: z.any(),
+    tags: z.array(tagSchema),
+    anchor: z.string().optional(),
+    signer: z.any().nullish()
+  }))
+  .returns(z.promise(
+    z.object({
+      id: z.string(),
+      raw: z.any(),
+    }).passthrough()
+  ))
+
+export const sendSignedMessageSchema = z.function()
+  .args(z.object({
+    id: z.string(),
+    raw: z.any(),
+  }))
+  .returns(z.promise(
+    z.object({
+      messageId: z.string(),
+    }).passthrough()
+  ))
+
 export const deployProcessSchema = z.function()
   .args(z.object({
     data: z.any(),

--- a/connect/src/lib/message/index.js
+++ b/connect/src/lib/message/index.js
@@ -4,7 +4,7 @@ import { of } from 'hyper-async'
 // eslint-disable-next-line no-unused-vars
 import { Types } from '../../dal.js'
 import { errFrom } from '../utils.js'
-import { uploadMessageWith } from './upload-message.js'
+import { prepareMessageWith, sendSignedMessageWith, uploadMessageWith } from './upload-message.js'
 
 /**
  * @typedef Env1
@@ -29,6 +29,30 @@ export function messageWith (env) {
   return ({ process, data, tags, anchor, signer }) => {
     return of({ id: process, data, tags, anchor, signer })
       .chain(uploadMessage)
+      .map((ctx) => ctx.messageId)
+      .bimap(errFrom, identity)
+      .toPromise()
+  }
+}
+
+export function prepareWith (env) {
+  const prepareMessage = prepareMessageWith(env)
+
+  return ({ process, data, tags, anchor, signer }) => {
+    return of({ id: process, data, tags, anchor, signer })
+      .chain(prepareMessage)
+      .map((ctx) => ctx)
+      .bimap(errFrom, identity)
+      .toPromise()
+  }
+}
+
+export function signedMessageWith (env) {
+  const sendSignedMessage = sendSignedMessageWith(env)
+
+  return ({ id, raw }) => {
+    return of({ id, raw })
+      .chain(sendSignedMessage)
       .map((ctx) => ctx.messageId)
       .bimap(errFrom, identity)
       .toPromise()

--- a/connect/test/e2e/node-esm/index.test.js
+++ b/connect/test/e2e/node-esm/index.test.js
@@ -5,9 +5,22 @@ import assert from 'node:assert/strict'
  * Ensure that npm link has been ran prior to running these tests
  * (simply running npm run test:integration will ensure npm link is ran)
  */
-import { dryrun } from '@permaweb/aoconnect'
+import { dryrun, connect, createSigner } from '@permaweb/aoconnect'
 
 const PROCESS = 'f6Ie4lnI-g_on29WbRSevAI8f6QTrlTXG1Xb0-TV_Sc'
+
+// this is a test wallet do not use for anything other than testing
+const WALLET = {
+  kty: 'RSA',
+  n: 'x5wjDziDSmSCvrWTiWk4avD-2DmolJHV6FOqwX8Dv4qvAJUDLq8kGg4r5NGj6yWS_f1N58FyhuAKcNgwBBj5Api5Kx5siL3vvcGywUaIID4wSn0BBjiTOf-IyEp0Ch4esGcf5fxNTzhX5X_2V8uPeXCGI-fbm877swOtgDSPc-ICAbML_CI0lOE60IP-KuWG7N0nsfibfDKs5fDv-JJTl21Dzxdryq44O873Kuyg9uOYIBW454UyBAYNMlSoMO753oLJvQvKi5n5X3ldnexD9bAwSzrjx1uhmtEr98ffxuplwsu0RkBOfolZS7GrD1mA_9zWKba-rreTus69gvbjSnHcQOkn6w11mGlL0_v95CN4kmthxlhuxPQS2R1pdkNYiX9IuULZcet-CO9Cnm6YDsNyvc84ly-iniUUR9Op2DWLzMuwNz9V-qJioKmGWmVE8V3tcu8RheAXnc2EoNwp3nhwV9a0GTcmrH7Dbpk-i60x75raxAYi5w_NAp44jddxueyxthW-3uyQmVtq_t-j1lMmrInTtRoIXi84bfZYzsxDqzx4E56xB2I7wQcOg2JSzLNVmzo6x2gVUSb9K2yCoIgM55eTdSS7sFG_fT60ftvR-RJR4fOpMHbMA8-aOcs6CLgKxFaVrVEWcSKpodKl_wjXXYJnPZE-xrXRyVwtx-c',
+  e: 'AQAB',
+  d: 'QMVnkv7Ri4hF7MBa2ZHtHraI230KOPuBn9vWYudmPfcwhk3UNIfcfR_wGlX0jM8qfYR-jR92nFGC0c809X9s_ey02UsMCOspKjf6W0EZ1uyXGvSpKm2dSIqkxely8f2IE9HCxgwywewUiYIWW7LQIaXjwS7xUgO-JP6ihCGKEx5ZbFe_IdevnEfhn9vU0_Ka761rvhJf0dNXy119YPmKam6oPEDrV19lG_MyvRj_ul1r9a1WzLmp2yhji9twoEBLkGp8L_3tgZM7GkH1oNMT0luTsDWxx_Tx4ZzSWZrgAFn7H1SecNVZIzJKaYeDbH2soFn2nJ6SDXvAUjPXxvF6GxCBp5I40mSaQW8CppI-ZWw1dbxMRjv2IQHAxsMN_TM-vk0YmjrzOr5SVWkZ3Eib6nor8kP9g0fdsA7Wlhocop8JhjdQ7XDxm0n-VLg75Wnk0o4hnmvYq5jnJg5k6mE0mBQ15mBgC8MhPZTb9VLySl_CXsXzLdT0UuOKpDGbHiWdVjT3Yo_afZt75vzQ0ys1Y5AILlFlibRyVOLnT2YE6906U3DkQLWYTs6XGWiYYS7rDPnZc24xhTj3WtCubINBOCfbcU558klgxM2Mp-TbFvLu0WPy-neeMopCsLbf-sBjWSdGE3RNSV9IuJWV4rQ2XEvtz4xS_E5-9BGw3IW-eaE',
+  p: '-3KdF6fI22lJ9Kv0HPMJmB4I3KgHgSpnkx99MirabiEFq3Trd5B_6iIeaCz3IKaPMvpujRTmJatNLaw2KNhtETaHQqJhw-_X82CJaYVJSFrmjnltD7dUIJW3LLokq4F7YiObd_oGWb75YKLx8WobX7E4BJd-8Bbcz2LsReYBLim6KKzzQPIw-uXfMcF_pnWA7W7S5JSBKtp458Mo6MYITlv4iAhU5cgXvZiURa57I7woTuSgl9Pmzn_ZR83tbmXK6EJA5J2nzavUgUTOaBmCkNGWztDvsb3XUwtcW48RQgDoHP6dlS4ZX7qBt5shvkDADj4Rc-X-V0pbqkWLCLKRvw',
+  q: 'yzlFM4JXVpBEO2s_2fmMDKGP6p-d2pv3M54-hjBHyvYOy8Zs_WrrlRm12zDXvV1YfOpHswKk3SxO9jgTAdHd_QPnXTKpO15IriuKhODPK9zRsM1pEm2tskfdv-KsE2TKULVWxBsS_sMn4pGFgTFIrE4aXezvnWBU_DBO31lRWnBHxflCJ3zl68YxNbn3Er--R4GBpyBle500-tiONDYh4eoY_TKlG3b6x4x4n1u5qz2WGr1VKhUro5GFvTj0WRlZvYGXMfIoTqu5dEApMsfRPq1qAcWU-tzy6FF1nwjypkgbr8lCcDYhNr64eRyCUUuArcVi84iIzxD3KNx2S6UD2Q',
+  dp: '1f1ej-ks2P2sANvuLkzvl1PIOvGNIXHTH7QmufEaX6sexiIE2oZRNhK_Se0qi9D0AXB7cPmeO-SjFAGBPhWiDIoZZq4HAdc2M1uu1eymxzsFB69zD3L315tSfnAUERlqxcSD5QEVMn-Cf6lsugWRMkkB4XaEgxMR7DTF2165Fm5QjZlSk60J3hyPbCq-1g0eIfK06-8uVigDyUmfoSoXm4hN5IciqUM2YRZe6UZqaakRrMKJoWym-op3gdJRBCkBG9R2oZlCW5imizThbFp5cYHNFElgFCX6ACSk_w6soz1eTH6r4W-QDJYPGxCdEOrOB9DuzXGomOUhSbFRd59wxQ',
+  dq: 'GmasSM7MDeDcHGQIfYbf3Nw4WCC4XygX60rJkKFBEmr47RwwGJQFWu9mIr2rqVwxHLlK60SSqnERKQeL4JalIjOZoQ_t0FqlUosxiaWzBF3BmBh3Z_97q0eO1VjbRgG4DtggF4X058furI5_K5N9f3T-E-muD2HuaHzWIkn2OauQh3WkVIDzVbf_uJ0aLgNe8ucuMsoQpQh9U4FCqCHIMRM6f9pOfMzuM3JaUUmXS1nK4Fpsb_UkIDHNkBGQHOsgL3BgdgqhlebVRvb24zP2SRA6T1Sd0CFYJTo_75M4AsYnYqTgzrcZhYUtbf54J5uJcgnMmxrHuy7XDSXm8FjVsQ',
+  qi: 'HJhf2ZP_PczoOoEMAw3cN6wdrZLG9J465tDjZ4HYqL9vrzPs7fPrXWJo4-WA-p_2IDXCkMP_t6H6JFyK1xHmDmjNpP7XlTwBb_hcEgn0W3dvmZ597Ey-B38IZfn0J4Wq3s34kcq3tprB5rG08qTm4d_tG-sln8Z7Ey-bLKTWPL_kIqpTCJ0H7cGvFVRMGN2dc9nPb4MYFRXhxZS7JF4SQJyRwPuHEMsY97Ph2IpNYpxKTGR1LfqWwSwnwrfyY_Y8sgkHMSNDvZcdGmaEYxhzTXa9xFGUdEFn2IAUIdvVz0aCBqC0soyfrkF955SDbCkbD2QxhyLX1DBVBcw_HEUCRA'
+}
 
 test('integration - dryrun', async () => {
   const result = await dryrun({
@@ -26,4 +39,22 @@ test('integration - dryrun', async () => {
   })
   console.log(JSON.stringify(result, null, 2))
   assert.ok(true)
+})
+
+test('integration - sign & send message', async () => {
+  const { signMessage, sendSignedMessage } = connect({ MODE: 'legacy' });
+
+  const signedMessage = await signMessage({
+    process: PROCESS,
+    tags: [
+      { name: 'Action', value: 'Balance' },
+      { name: 'Recipient', value: 'NlSfGLmEEwRfV2ITvj7QaCcJu59QSPGZ8_rSuioAQKA' },
+    ],
+    signer: createSigner(WALLET)
+  });
+
+  console.log(signedMessage)
+  const response = await sendSignedMessage(signedMessage);
+  console.log(`Response: ${response}`);
+  assert.ok(true);
 })

--- a/connect/test/e2e/package.json
+++ b/connect/test/e2e/package.json
@@ -3,7 +3,7 @@
   "description": "integration test suites for @permaweb/aoconnect",
   "type": "module",
   "scripts": {
-    "test": "npm run test:node-cjs && npm run test:node-esm && npm run test:browser && npm run test:m0",
+    "test": "npm run test:node-cjs && npm run test:node-esm && npm run test:browser",
     
     "test:browser": "cd ./browser-esm && npm i --legacy-peer-deps && npm start",
     "test:node-cjs": "cd ./node-cjs && npm i && npm start",


### PR DESCRIPTION
This PR adds two new APIs to aoconnect. The first is a signMessage method which takes the same arguments passed to message, however only returns a signed data item / http message. The second method added is sendSignedMessage, which takes the previously created signed data item / http message and performs the dispatch of the message.