### PR TITLE
fix: need to check for null on content-type

### DIFF
--- a/connect/src/lib/request/index.js
+++ b/connect/src/lib/request/index.js
@@ -49,7 +49,7 @@ function transformToMap (result) {
   // question should we return a js Map to ensure order consistency?
   let map = {}
   const res = result
-  if (res.headers.get('content-type').startsWith('multipart')) {
+  if (res.headers.get('content-type') && res.headers.get('content-type').startsWith('multipart')) {
     map = mergeRight(map, 
       Object.fromEntries(
         parseMultipartContent(res.body, res.headers.get('content-type'))


### PR DESCRIPTION
This PR prevents errors when handling responses lacking a 'Content-Type' header. A null check ensures the application gracefully handles these cases, improving robustness.