### PR TITLE
Jfrain99/mu hb compat

### DIFF
--- a/connect/src/hb.playground.js
+++ b/connect/src/hb.playground.js
@@ -9,7 +9,7 @@ import { join } from 'node:path'
 import Arweave from 'arweave'
 import { tap } from 'ramda'
 
-import { connect } from './index.js'
+import { connect, createDataItemSigner } from './index.js'
 
 describe('hb playground', () => {
   /**
@@ -30,54 +30,24 @@ describe('hb playground', () => {
     test('should relay the message through HyperBEAM', async () => {
       const wallet = JSON.parse(readFileSync(tmpWallet).toString())
 
-      const { request, spawn, message, result, createDataItemSigner } = connect({
-        MODE: 'mainnet',
-        wallet,
-        device: 'process@1.0',
-        URL: process.env.HB_URL || 'http://localhost:8734'
+      const { message } = connect({
+        MODE: 'legacy',
+        MU_URL: 'http://localhost:3004'
       })
 
-      const address = await fetch(process.env.HB_URL + '/~meta@1.0/info/address').then((res) => res.text())
-
-      console.log(address)
-      // uncomment examples as needed
-
-      const res = await request(`~simple-pay@1.0/balance?address=${address}`, {
-        method: 'GET'
+      const msg1 = await message({
+        process: 'oQHqnr9IZkrA6ENrgVy9QYMlpDUixCHqN5Gl_FjpFj0',
+        signer: createDataItemSigner(wallet),
+        tags: [
+          { name: 'Variant', value: 'ao.N.1' },
+          { name: 'Type', value: 'Message' },
+          { name: 'Action', value: 'Foo' },
+          { name: 'TagData', value: 'Foo' }
+        ],
+        data: 'ao.send({ Target = ao.id, Data = "Resultant Message" })'
       })
 
-      // const p = await spawn({
-      //   scheduler: address,
-      //   module: 'bkjb55i07GUCUSWROtKK4HU1mBS_X0TyH3M5jMV6aPg',
-      //   data: 'print("Process initialized.")',
-      //   tags: [
-      //     { name: 'device', value: 'process@1.0' },
-      //     { name: 'scheduler-device', value: 'scheduler@1.0' },
-      //     { name: 'execution-device', value: 'compute-lite@1.0' },
-      //     { name: 'authority', value: address },
-      //     { name: 'scheduler-location', value: address },
-      //     { name: 'scheduler', value: address },
-      //     { name: 'random-seed', value: randomBytes(16).toString('hex') }
-      //   ],
-      //   signer: createDataItemSigner()
-      // }).then(tap(console.log))
-
-      // const m = await message({
-      //   process: p,
-      //   tags: [
-      //     { name: 'Action', value: 'Eval' },
-      //     { name: 'Data-Protocol', value: 'ao' },
-      //     { name: 'Variant', value: 'ao.TN.1' },
-      //     { name: 'Type', value: 'Message' }
-      //   ],
-      //   data: "Send({ Target = ao.id, Data = 'gday mate' })",
-      //   signer: createDataItemSigner()
-      // }).then(tap(console.log))
-
-      // console.log('READY TO LOAD RESULT. m:', m)
-
-      // const r = await result({ message: m, process: p })
-      //   .then(tap(console.log)).catch(console.error)
+      console.log({ msg1 })
     })
   })
 })

--- a/connect/src/lib/message/upload-message.js
+++ b/connect/src/lib/message/upload-message.js
@@ -115,9 +115,9 @@ export function uploadMessageWith (env) {
     return of(ctx)
       .chain(buildTags)
       .chain(buildData)
-      .chain(fromPromise(({ id, data, tags, anchor, signer }) =>
-        deployMessage({ processId: id, data, tags, anchor, signer: signerSchema.implement(signer || env.signer) })
-      ))
+      .chain(fromPromise(({ id, data, tags, anchor, signer }) => {
+        return deployMessage({ processId: id, data, tags, anchor, signer: signerSchema.implement(signer || env.signer) })
+      }))
       .map(res => assoc('messageId', res.messageId, ctx))
   }
 }

--- a/servers/mu/package.json
+++ b/servers/mu/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@permaweb/ao-scheduler-utils": "^0.0.25",
+    "@permaweb/aoconnect": "^0.0.85",
     "arbundles": "0.11.0",
     "arweave": "^1.14.4",
     "async-mutex": "^0.5.0",

--- a/servers/mu/package.json
+++ b/servers/mu/package.json
@@ -19,8 +19,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@permaweb/ao-scheduler-utils": "^0.0.25",
-    "@permaweb/aoconnect": "^0.0.85",
+    "@permaweb/ao-scheduler-utils": "^0.0.26",
+    "@permaweb/aoconnect": "^0.0.86",
     "arbundles": "0.11.0",
     "arweave": "^1.14.4",
     "async-mutex": "^0.5.0",

--- a/servers/mu/src/domain/api/processMsg.js
+++ b/servers/mu/src/domain/api/processMsg.js
@@ -20,13 +20,14 @@ export function processMsgWith ({
   writeDataItemArweave,
   isWallet,
   fetchSchedulerProcess,
+  fetchHyperBeamResult,
   topUp,
   RELAY_MAP
 }) {
   const buildTx = buildTxWith({ buildAndSign, logger, locateProcess, fetchSchedulerProcess, isWallet })
   const writeMessage = writeMessageTxWith({ writeDataItem, logger, writeDataItemArweave, RELAY_MAP, topUp })
   const getCuAddress = getCuAddressWith({ selectNode, logger })
-  const pullResult = pullResultWith({ fetchResult, logger })
+  const pullResult = pullResultWith({ fetchResult, fetchHyperBeamResult, logger })
 
   return (ctx) => {
     return of(ctx)

--- a/servers/mu/src/domain/api/sendDataItem.test.js
+++ b/servers/mu/src/domain/api/sendDataItem.test.js
@@ -21,7 +21,8 @@ describe('sendDataItemWith', () => {
               { name: 'Data-Protocol', value: 'ao' },
               { name: 'Type', value: 'Process' },
               { name: 'Scheduler', value: 'scheduler-id' }
-            ]
+            ],
+            data: 'test-data'
           }),
           writeDataItem: async (res) => ({
             ...res,
@@ -66,7 +67,8 @@ describe('sendDataItemWith', () => {
               { name: 'Data-Protocol', value: 'ao' },
               { name: 'Type', value: 'Process' },
               { name: 'Scheduler', value: 'scheduler-id' }
-            ]
+            ],
+            data: 'test-data'
           }),
           writeDataItem: async (res) => ({
             ...res,
@@ -113,7 +115,8 @@ describe('sendDataItemWith', () => {
               { name: 'Data-Protocol', value: 'ao' },
               { name: 'Type', value: 'Process' },
               { name: 'Scheduler', value: 'scheduler-id' }
-            ]
+            ],
+            data: 'test-data'
           }),
           writeDataItem: async (res) => ({
             ...res,

--- a/servers/mu/src/domain/clients/scheduler.js
+++ b/servers/mu/src/domain/clients/scheduler.js
@@ -2,8 +2,9 @@ import { identity } from 'ramda'
 import { of, fromPromise, Rejected } from 'hyper-async'
 import { backoff, okRes } from '../utils.js'
 import { withTimerMetricsFetch } from '../lib/with-timer-metrics-fetch.js'
+import { connect, createDataItemSigner } from '@permaweb/aoconnect'
 
-function writeDataItemWith ({ fetch, histogram, logger }) {
+function writeDataItemWith ({ fetch, histogram, logger, wallet }) {
   const suFetch = withTimerMetricsFetch({
     fetch,
     timer: histogram,
@@ -20,52 +21,104 @@ function writeDataItemWith ({ fetch, histogram, logger }) {
     }),
     logger
   })
+  const hbFetch = withTimerMetricsFetch({
+    fetch,
+    timer: histogram,
+    startLabelsFrom: () => ({
+      operation: 'writeDataItemHyperBeam'
+    }),
+    logger
+  })
   /**
    * writeDataItem
-   * Given a dataItem and a suUrl, forward the message to the SU
+   * Given a dataItem and a suUrl, forward the message to the SU or HyperBeam scheduler
    * to be posted to Arweave.
    *
    * @param data - the data to forward
-   * @param suUrl - the SU to forward the data to
+   * @param suUrl - the SU or HyperBeam scheduler URL
    * @param logId - The logId to aggregate the logs by
+   * @param schedulerType - 'legacy' or 'hyperbeam' to determine endpoint
    *
    * @returns
    * id - the tx-id of the data item
    * timestamp
    */
-  return async ({ data, suUrl, logId }) => {
+  return async ({ data, suUrl, logId, schedulerType = 'legacy', processId, id, tags = [], dataStr }) => {
+    const endpoint = schedulerType === 'hyperbeam'
+      ? `${suUrl}/${processId}~process@1.0/push`
+      : suUrl
+    const fetchClient = schedulerType === 'hyperbeam' ? hbFetch : suFetch
+
     return of(Buffer.from(data, 'base64'))
-      .map(logger.tap({ log: `Forwarding message to SU ${suUrl}`, logId }))
+      .map(logger.tap({
+        log: `Forwarding message to ${schedulerType} scheduler ${endpoint}`,
+        logId
+      }))
       .chain(
-        fromPromise((body) =>
-          suFetch(suUrl, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/octet-stream',
-              Accept: 'application/json'
-            },
-            redirect: 'manual',
-            body
-          }).then(async (response) => {
-            /*
-            After upgrading to node 22 we have to handle
-            the redirects manually otherwise fetch throws
-            an error
-          */
-            if ([307, 308].includes(response.status)) {
-              const newUrl = response.headers.get('Location')
-              return suRedirectFetch(newUrl, {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/octet-stream',
-                  Accept: 'application/json'
-                },
-                body
-              })
+        fromPromise((body) => {
+          if (schedulerType === 'hyperbeam') {
+            // Use ao connect for HyperBeam push requests
+            const aoConnect = connect({
+              MODE: 'mainnet',
+              device: 'process@1.0',
+              signer: createDataItemSigner(wallet),
+              URL: suUrl
+            })
+
+            // Helper function to convert tags array to object (like assoc in mainnet.js)
+            const tagsToObj = tags.reduce((acc, tag) => {
+              acc[tag.name] = tag.value
+              return acc
+            }, {})
+
+            // Create push request parameters following mainnet.js pattern
+            const pushParams = {
+              type: 'Message',
+              path: `/${processId}~process@1.0/push`,
+              method: 'POST',
+              ...tagsToObj,
+              'data-protocol': 'ao',
+              'scheduler-device': 'scheduler@1.0',
+              'push-device': 'push@1.0',
+              variant: 'ao.N.1',
+              target: processId,
+              signingFormat: 'ANS-104',
+              'accept-bundle': 'true',
+              'accept-codec': 'httpsig@1.0',
+              data: dataStr
             }
-            return response
-          })
-        )
+
+            return aoConnect.request(pushParams)
+          } else {
+            return fetchClient(endpoint, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/octet-stream',
+                Accept: 'application/json'
+              },
+              redirect: 'manual',
+              body
+            }).then(async (response) => {
+              /*
+              After upgrading to node 22 we have to handle
+              the redirects manually otherwise fetch throws
+              an error
+            */
+              if ([307, 308].includes(response.status)) {
+                const newUrl = response.headers.get('Location')
+                return suRedirectFetch(newUrl, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/octet-stream',
+                    Accept: 'application/json'
+                  },
+                  body
+                })
+              }
+              return response
+            })
+          }
+        })
       )
       .bimap((e) => {
         logger({ log: `Error while communicating with SU: ${e}`, logId })
@@ -74,6 +127,13 @@ function writeDataItemWith ({ fetch, histogram, logger }) {
       .bichain(
         (err) => Rejected(err),
         fromPromise(async (res) => {
+          if (schedulerType === 'hyperbeam') {
+            if (+res.status === 200) {
+              // TODO: fix this
+              return { id, timestamp: Date.now(), slot: +res.slot }
+            }
+            throw new Error(`${res.status}: Error posting to HyperBeam`)
+          }
           if (!res?.ok) {
             const text = await res.text()
             throw new Error(`${res.status}: ${text}`)
@@ -249,8 +309,69 @@ function fetchSchedulerProcessWith ({
   }
 }
 
+function fetchHyperBeamResultWith ({ fetch, histogram, logger }) {
+  const hbFetch = withTimerMetricsFetch({
+    fetch,
+    timer: histogram,
+    startLabelsFrom: () => ({
+      operation: 'fetchHyperBeamResult'
+    }),
+    logger
+  })
+
+  /**
+   * fetchHyperBeamResult
+   * Fetches result from HyperBeam scheduler using the new endpoint format
+   *
+   * @param {string} processId - The process ID
+   * @param {string} suUrl - The HyperBeam scheduler URL
+   * @param {string} assignmentNum - The assignment/slot number
+   * @param {string} logId - The logId to aggregate the logs by
+   *
+   * @returns result data from HyperBeam scheduler
+   */
+  return async ({ processId, suUrl, assignmentNum, logId }) => {
+    const resultUrl = `${suUrl}/${processId}~process@1.0/compute&slot=${assignmentNum}/results/serialize~json@1.0`
+
+    logger({ log: `Fetching result from HyperBeam: ${resultUrl}`, logId })
+
+    return backoff(
+      () => hbFetch(resultUrl).then((res) => okRes(res)),
+      {
+        maxRetries: 5,
+        delay: 500,
+        log: logger,
+        logId,
+        name: `fetchHyperBeamResult(${processId}, ${assignmentNum})`
+      }
+    )
+      .then(async (res) => {
+        if (!res?.ok) {
+          const text = await res.text()
+          throw new Error(`${res.status}: ${text}`)
+        }
+        return res.json()
+      })
+      .then((res) => {
+      // Parse result so that MU can use it
+        const result = JSON.parse(res.json.body)
+        // Attach isHyperBeamResult to result
+        return { ...result, isHyperBeamResult: true }
+      })
+      .then((result) => {
+        logger({ log: 'Successfully fetched result from HyperBeam scheduler', logId })
+        return result
+      })
+      .catch((e) => {
+        logger({ log: `Error fetching result from HyperBeam scheduler: ${e}`, logId })
+        throw e
+      })
+  }
+}
+
 export default {
   writeDataItemWith,
   writeAssignmentWith,
-  fetchSchedulerProcessWith
+  fetchSchedulerProcessWith,
+  fetchHyperBeamResultWith
 }

--- a/servers/mu/src/domain/dal.js
+++ b/servers/mu/src/domain/dal.js
@@ -74,7 +74,7 @@ export const resultSchema = z.function()
 
 export const graphqlReturnSchema = z.function()
   .args(
-    z.array(),
+    z.array()
   )
   .returns(
     z.any()
@@ -209,14 +209,20 @@ export const writeDataItemSchema = z.function()
     z.object({
       data: z.string(),
       suUrl: z.string(),
-      logId: z.string().nullish()
+      logId: z.string().nullish(),
+      schedulerType: z.string().optional(),
+      id: z.string().optional(),
+      processId: z.string().optional(),
+      tags: tagArraySchema.optional(),
+      dataStr: z.string().optional()
     })
   )
   .returns(
     z.promise(
       z.object({
         id: z.string(),
-        timestamp: z.coerce.number()
+        timestamp: z.coerce.number(),
+        slot: z.coerce.number().nullish()
       })
     )
   )

--- a/servers/mu/src/domain/index.js
+++ b/servers/mu/src/domain/index.js
@@ -84,6 +84,7 @@ const arweave = Arweave.init()
  */
 export const createApis = async (ctx) => {
   const CU_URL = ctx.CU_URL
+  const MU_WALLET = ctx.MU_WALLET
   const UPLOADER_URL = ctx.UPLOADER_URL
   const GRAPHQL_URL = ctx.GRAPHQL_URL
   const ARWEAVE_URL = ctx.ARWEAVE_URL
@@ -165,7 +166,7 @@ export const createApis = async (ctx) => {
     minWorkers: queueIds.length, // We must have as many workers as there are queues to persist
     maxWorkers: ctx.MAX_WORKERS,
     onTerminateWorker: (worker) => {
-      console.log('123Terminating worker', worker)
+      console.log('Terminating worker', worker)
     },
     onCreateWorker: () => {
       let queueId = randomBytes(8).toString('hex')
@@ -219,11 +220,12 @@ export const createApis = async (ctx) => {
     createDataItem,
     locateScheduler: raw,
     locateProcess: locate,
-    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: sendDataItemLogger }),
+    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: sendDataItemLogger, wallet: MU_WALLET }),
     fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: sendDataItemLogger }),
+    fetchHyperBeamResult: schedulerClient.fetchHyperBeamResultWith({ fetch, histogram, logger: sendDataItemLogger }),
     fetchSchedulerProcess: schedulerClient.fetchSchedulerProcessWith({ getByProcess, setByProcess, fetch, histogram, logger: sendDataItemLogger }),
     crank,
-    isWallet: gatewayClient.isWalletWith({ fetch, histogram, ARWEAVE_URL, logger: sendDataItemLogger }),
+    isWallet: gatewayClient.isWalletWith({ fetch, histogram, ARWEAVE_URL, GRAPHQL_URL, logger: sendDataItemLogger }),
     logger: sendDataItemLogger,
     writeDataItemArweave: uploaderClient.uploadDataItemWith({ UPLOADER_URL, logger: sendDataItemLogger, fetch, histogram }),
     spawnPushEnabled: SPAWN_PUSH_ENABLED,
@@ -400,11 +402,12 @@ export const createResultApis = async (ctx) => {
     createDataItem,
     locateScheduler: raw,
     locateProcess: locate,
-    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: processMsgLogger }),
+    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: processMsgLogger, wallet: MU_WALLET }),
     fetchSchedulerProcess: schedulerClient.fetchSchedulerProcessWith({ getByProcess, setByProcess, fetch, histogram, logger: processMsgLogger }),
     buildAndSign: signerClient.buildAndSignWith({ MU_WALLET, logger: processMsgLogger }),
     fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: processMsgLogger }),
-    isWallet: gatewayClient.isWalletWith({ fetch, histogram, ARWEAVE_URL, logger: processMsgLogger, setById, getById }),
+    fetchHyperBeamResult: schedulerClient.fetchHyperBeamResultWith({ fetch, histogram, logger: processMsgLogger }),
+    isWallet: gatewayClient.isWalletWith({ fetch, histogram, ARWEAVE_URL, GRAPHQL_URL, logger: processMsgLogger, setById, getById }),
     writeDataItemArweave: uploaderClient.uploadDataItemWith({ UPLOADER_URL, logger: processMsgLogger, fetch, histogram }),
     RELAY_MAP,
     topUp: RelayClient.topUpWith({
@@ -423,7 +426,7 @@ export const createResultApis = async (ctx) => {
     locateProcess: locate,
     locateNoRedirect,
     buildAndSign: signerClient.buildAndSignWith({ MU_WALLET, logger: processMsgLogger }),
-    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: processSpawnLogger }),
+    writeDataItem: schedulerClient.writeDataItemWith({ fetch, histogram, logger: processSpawnLogger, wallet: MU_WALLET }),
     fetchResult: cuClient.resultWith({ fetch: fetchWithCache, histogram, CU_URL, logger: processMsgLogger }),
     fetchSchedulerProcess: schedulerClient.fetchSchedulerProcessWith({ getByProcess, setByProcess, fetch, histogram, logger: processMsgLogger }),
     spawnPushEnabled: SPAWN_PUSH_ENABLED

--- a/servers/mu/src/domain/lib/build-success-tx.js
+++ b/servers/mu/src/domain/lib/build-success-tx.js
@@ -1,6 +1,6 @@
 import { of, fromPromise, Resolved } from 'hyper-async'
 import z from 'zod'
-import { assoc, __, defaultTo, concat } from 'ramda'
+import { assoc, __, defaultTo } from 'ramda'
 
 import { checkStage, removeTagsByNameMaybeValue } from '../utils.js'
 
@@ -27,20 +27,31 @@ export function buildSuccessTxWith ({ buildAndSign, logger }) {
        * Append tags explicitly set by the MU on the success
        * message send to the spawning process
        */
-      .map(concat(__, [
-        { name: 'Data-Protocol', value: 'ao' },
-        { name: 'Variant', value: 'ao.TN.1' },
-        { name: 'Type', value: 'Message' },
-        /**
-         * aos interoperability
-         *
-         * set the Process tag to the id of the newly spawned Process
-         * and Action to 'Spawned' such that it can be handled
-         * by an aos Handler
-         */
-        { name: 'Process', value: ctx.processTx },
-        { name: 'Action', value: 'Spawned' }
-      ]))
+      .map((tags) => {
+        const successTags = [
+          { name: 'Data-Protocol', value: 'ao' },
+          { name: 'Type', value: 'Message' },
+          /**
+           * aos interoperability
+           *
+           * set the Process tag to the id of the newly spawned Process
+           * and Action to 'Spawned' such that it can be handled
+           * by an aos Handler
+           */
+          { name: 'Process', value: ctx.processTx },
+          { name: 'Action', value: 'Spawned' }
+        ]
+
+        // Preserve the original Variant tag from the spawn if it exists
+        const originalVariant = ctx.cachedSpawn.spawn.Tags?.find(tag => tag.name === 'Variant')
+        if (originalVariant) {
+          successTags.push({ name: 'Variant', value: originalVariant.value })
+        } else {
+          successTags.push({ name: 'Variant', value: 'ao.TN.1' })
+        }
+
+        return tags.concat(successTags)
+      })
       .chain(fromPromise((tags) => buildAndSign({
         processId: ctx.cachedSpawn.processId,
         tags

--- a/servers/mu/src/domain/lib/build-success-tx.js
+++ b/servers/mu/src/domain/lib/build-success-tx.js
@@ -44,8 +44,8 @@ export function buildSuccessTxWith ({ buildAndSign, logger }) {
 
         // Preserve the original Variant tag from the spawn if it exists
         const originalVariant = ctx.cachedSpawn.spawn.Tags?.find(tag => tag.name === 'Variant')
-        if (originalVariant) {
-          successTags.push({ name: 'Variant', value: originalVariant.value })
+        if (originalVariant?.value === 'ao.N.1') {
+          successTags.push({ name: 'Variant', value: 'ao.N.1' })
         } else {
           successTags.push({ name: 'Variant', value: 'ao.TN.1' })
         }

--- a/servers/mu/src/domain/lib/build-success-tx.test.js
+++ b/servers/mu/src/domain/lib/build-success-tx.test.js
@@ -12,7 +12,7 @@ describe('buildSuccessTx', () => {
   test('build spawn success msg', async () => {
     const spawnedTags = [
       { name: 'Type', value: 'Process' },
-      { name: 'Variant', value: 'ao.TN.2' },
+      { name: 'Variant', value: 'ao.TN.1' },
       { name: '_Ref', value: '123' },
       { name: 'Foo', value: 'Bar' }
     ]
@@ -28,10 +28,103 @@ describe('buildSuccessTx', () => {
             { name: 'Foo', value: 'Bar' },
             // added by Mu
             { name: 'Data-Protocol', value: 'ao' },
-            { name: 'Variant', value: 'ao.TN.1' },
             { name: 'Type', value: 'Message' },
             { name: 'Process', value: 'pid-2' },
-            { name: 'Action', value: 'Spawned' }
+            { name: 'Action', value: 'Spawned' },
+            { name: 'Variant', value: 'ao.TN.1' }
+          ]
+        )
+        return {
+          id: 'new-id',
+          data: Buffer.alloc(0),
+          processId: 'pid-1'
+        }
+      },
+      logger
+    })
+
+    const result = await buildSuccessTx({
+      cachedSpawn: {
+        processId: 'pid-1',
+        spawn: {
+          Tags: spawnedTags
+        }
+      },
+      processTx: 'pid-2'
+    }).toPromise()
+
+    assert.equal(result.spawnSuccessTx.id, 'new-id')
+  })
+
+  test('build spawn success msg with variant ao.N.1', async () => {
+    const spawnedTags = [
+      { name: 'Type', value: 'Process' },
+      { name: 'Variant', value: 'ao.N.1' },
+      { name: '_Ref', value: '123' },
+      { name: 'Foo', value: 'Bar' }
+    ]
+
+    const buildSuccessTx = buildSuccessTxWith({
+      buildAndSign: async (stx) => {
+        assert.equal(stx.processId, 'pid-1')
+        assert.deepStrictEqual(
+          stx.tags,
+          [
+            // from spawn.Tags
+            { name: '_Ref', value: '123' },
+            { name: 'Foo', value: 'Bar' },
+            // added by Mu
+            { name: 'Data-Protocol', value: 'ao' },
+            { name: 'Type', value: 'Message' },
+            { name: 'Process', value: 'pid-2' },
+            { name: 'Action', value: 'Spawned' },
+            { name: 'Variant', value: 'ao.N.1' }
+          ]
+        )
+        return {
+          id: 'new-id',
+          data: Buffer.alloc(0),
+          processId: 'pid-1'
+        }
+      },
+      logger
+    })
+
+    const result = await buildSuccessTx({
+      cachedSpawn: {
+        processId: 'pid-1',
+        spawn: {
+          Tags: spawnedTags
+        }
+      },
+      processTx: 'pid-2'
+    }).toPromise()
+
+    assert.equal(result.spawnSuccessTx.id, 'new-id')
+  })
+  test('build spawn success msg with unknown variant', async () => {
+    const spawnedTags = [
+      { name: 'Type', value: 'Process' },
+      { name: 'Variant', value: 'ao.UNKNOWN.1' },
+      { name: '_Ref', value: '123' },
+      { name: 'Foo', value: 'Bar' }
+    ]
+
+    const buildSuccessTx = buildSuccessTxWith({
+      buildAndSign: async (stx) => {
+        assert.equal(stx.processId, 'pid-1')
+        assert.deepStrictEqual(
+          stx.tags,
+          [
+            // from spawn.Tags
+            { name: '_Ref', value: '123' },
+            { name: 'Foo', value: 'Bar' },
+            // added by Mu
+            { name: 'Data-Protocol', value: 'ao' },
+            { name: 'Type', value: 'Message' },
+            { name: 'Process', value: 'pid-2' },
+            { name: 'Action', value: 'Spawned' },
+            { name: 'Variant', value: 'ao.TN.1' }
           ]
         )
         return {

--- a/servers/mu/src/domain/lib/parse-data-item.js
+++ b/servers/mu/src/domain/lib/parse-data-item.js
@@ -25,6 +25,7 @@ export function parseDataItemWith ({ createDataItem, logger }) {
               owner: dataItem.owner,
               target: dataItem.target,
               tags: dataItem.tags,
+              data: Buffer.from(dataItem.data, 'base64').toString(),
               /**
                * For some reason, anchor is not included in the toJSON api on DataItem,
                * so we make sure to include it here

--- a/servers/mu/src/domain/lib/parse-data-item.js
+++ b/servers/mu/src/domain/lib/parse-data-item.js
@@ -25,7 +25,7 @@ export function parseDataItemWith ({ createDataItem, logger }) {
               owner: dataItem.owner,
               target: dataItem.target,
               tags: dataItem.tags,
-              data: Buffer.from(dataItem.data, 'base64').toString(),
+              data: Buffer.from(dataItem?.data, 'base64').toString(),
               /**
                * For some reason, anchor is not included in the toJSON api on DataItem,
                * so we make sure to include it here

--- a/servers/mu/src/domain/lib/parse-data-item.test.js
+++ b/servers/mu/src/domain/lib/parse-data-item.test.js
@@ -19,7 +19,8 @@ describe('parseDataItem', () => {
       anchor: 'foobar',
       tags: [
         { name: 'Foo', value: 'Bar' }
-      ]
+      ],
+      data: Buffer.from('test-data', 'utf-8')
     }
     const parseDataItem = parseDataItemWith({
       createDataItem: (raw) => {
@@ -45,7 +46,8 @@ describe('parseDataItem', () => {
       anchor: 'foobar',
       tags: [
         { name: 'Foo', value: 'Bar' }
-      ]
+      ],
+      data: 'test-data'
     })
   })
 })

--- a/servers/mu/src/domain/lib/spawn-process.js
+++ b/servers/mu/src/domain/lib/spawn-process.js
@@ -46,9 +46,12 @@ export function spawnProcessWith (env) {
       'Type'
     ].includes(tag.name))
 
-    // Preserve existing Variant tag if present, otherwise default to ao.N.1 for backwards compatibility
+    // Preserve ao.N.1 Variant tag if present,
+    // otherwise default to ao.TN.1 for backwards compatibility
     const existingVariant = Tags.find(tag => tag.name === 'Variant')
-    if (!existingVariant) {
+    if (existingVariant?.value === 'ao.N.1') {
+      tagsIn.push({ name: 'Variant', value: 'ao.N.1' })
+    } else {
       tagsIn.push({ name: 'Variant', value: 'ao.TN.1' })
     }
 

--- a/servers/mu/src/domain/lib/spawn-process.js
+++ b/servers/mu/src/domain/lib/spawn-process.js
@@ -43,13 +43,17 @@ export function spawnProcessWith (env) {
 
     const tagsIn = Tags.filter(tag => ![
       'Data-Protocol',
-      'Type',
-      'Variant'
+      'Type'
     ].includes(tag.name))
+
+    // Preserve existing Variant tag if present, otherwise default to ao.N.1 for backwards compatibility
+    const existingVariant = Tags.find(tag => tag.name === 'Variant')
+    if (!existingVariant) {
+      tagsIn.push({ name: 'Variant', value: 'ao.N.1' })
+    }
 
     tagsIn.push({ name: 'Data-Protocol', value: 'ao' })
     tagsIn.push({ name: 'Type', value: 'Process' })
-    tagsIn.push({ name: 'Variant', value: 'ao.TN.1' })
     tagsIn.push({ name: 'From-Process', value: ctx.cachedSpawn.processId })
 
     if (ctx.cachedSpawn.initialTxId) {

--- a/servers/mu/src/domain/lib/spawn-process.js
+++ b/servers/mu/src/domain/lib/spawn-process.js
@@ -49,7 +49,7 @@ export function spawnProcessWith (env) {
     // Preserve existing Variant tag if present, otherwise default to ao.N.1 for backwards compatibility
     const existingVariant = Tags.find(tag => tag.name === 'Variant')
     if (!existingVariant) {
-      tagsIn.push({ name: 'Variant', value: 'ao.N.1' })
+      tagsIn.push({ name: 'Variant', value: 'ao.TN.1' })
     }
 
     tagsIn.push({ name: 'Data-Protocol', value: 'ao' })

--- a/servers/mu/src/domain/utils.js
+++ b/servers/mu/src/domain/utils.js
@@ -233,6 +233,31 @@ export const okRes = (res) => {
 }
 
 /**
+ * Checks if a HB response is OK. Otherwise, throw response.
+ *
+ * @param {Response} res - The response to check
+ * @returns
+ */
+export const okResHb = (res) => {
+  if (+res.status === 200) return res
+  throw res
+}
+
+/**
+ * Checks if a message is a HyperBeam message.
+ *
+ * @param {Object} msg - The message to check
+ * @returns
+ */
+export const isHyperBeamMessage = (msg) => {
+  let tags = []
+  if (Array.isArray(msg)) tags = msg
+  else if (msg.tags) tags = msg.tags
+  else if (msg.dataItem.tags) tags = msg.Tags
+
+  return tags.find(tag => tag.name === 'Variant')?.value === 'ao.N.1'
+}
+/**
  * Checks if we are at a provided stage
  *
  * @param {String} stage - The stage to check against


### PR DESCRIPTION
Allows for MUs to handle HB requests (variant: ao.N.1). MUs, when receiving these messages, will now post schedule to the HB node (retrieved from scheduler location) and pull results from the HB node (config, set to router-1.forward.computer). It also pushes these messages.

Related changes:
In connect, no longer overwrite Variant to ao.TN.1 automatically.
In scheduler-utils, match tags case insensitively
